### PR TITLE
docs: sync control-plane main ruleset

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+## change id
+
+-
+
+## 관련 issue
+
+-
+
+## 대상 repo/service
+
+-
+
+## 변경 내용
+
+-
+
+## 테스트 여부
+
+-
+
+## 검수 포인트
+
+-
+
+## rollout/rollback 영향
+
+-
+
+## CLEVER PR review completion
+
+- target branch: `dev` / `main`
+- context docs checked:
+- PR 정보를 wiki에 올리지 않는다.
+- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
+- wiki/service context update result: `updated` / `not-needed`
+- service doc update:
+- wiki update:
+- clever-context-monorepo update:
+- linked issue close evidence:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 !/AGENTS.md
 !/README.md
 
+!/.github/
+!/.github/PULL_REQUEST_TEMPLATE.md
+
 !/.agent/
 !/.agent/skills/
 !/.agent/skills/bootstrap-clever-work/
@@ -46,6 +49,7 @@
 
 !/tests/
 !/tests/test_bootstrap_clever_work.py
+!/tests/test_gitignore_whitelist.py
 !/tests/test_issue_resolution_context_wiki_prompt.py
 !/tests/test_sync_issue_from_md.py
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,19 @@ Use `fixes`, `closes`, or similar GitHub keywords only when the PR merge is
 intended to close the referenced issue. For context linking without automatic
 closure, use plain issue mentions.
 
+## Control-plane Main Branch Contract
+
+The three CLEVER control-plane repositories are public and their `main`
+branches are protected by the GitHub ruleset `CLEVER protect main`:
+
+- `clever-agent-project`
+- `clever-context-monorepo`
+- `clever-change-control`
+
+Do not push directly to `main` for control-plane changes. Use a role-prefixed
+branch and open a PR into `main`. `main` PRs require at least one approval.
+Admin bypass is allowed only in `pull_request` mode.
+
 ## Branch Operating Contract
 
 Treat git branch roles like this:

--- a/README.md
+++ b/README.md
@@ -158,6 +158,23 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --curren
 GitHub Free 조직에서 private repo ruleset이 enforce되지 않는다.
 ruleset 기반으로 `main`/`dev` direct push를 막고 PR 필수 정책을 쓰려면 새 target repo를 public으로 생성한다.
 
+### control-plane repo 보호 기준
+
+3개 control-plane repo는 public으로 운영한다.
+
+- `clever-agent-project`
+- `clever-context-monorepo`
+- `clever-change-control`
+
+각 repo의 `main`은 GitHub ruleset `CLEVER protect main`으로 보호한다.
+
+- `main` direct push 금지
+- `main` 삭제 금지
+- force push 금지
+- `main` 변경은 PR 필수
+- PR 승인 1명 이상 필수
+- admin bypass는 `pull_request` 모드만 허용
+
 ### 세션 시작
 
 generic CLEVER startup은 `clever-agent-project`에서 시작한다.

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -159,6 +159,26 @@ generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-project`에서 시�
 
 즉 `superpowers`는 사용자 에이전트 환경에 설치되고, 새 프로젝트 repo는 그 환경 위에서 실행되는 작업 대상 repo가 된다.
 
+## Control-plane Repo 보호 기준
+
+아래 3개 control-plane repo는 public으로 운영한다.
+
+- `clever-agent-project`
+- `clever-context-monorepo`
+- `clever-change-control`
+
+각 repo의 `main`은 GitHub ruleset `CLEVER protect main`으로 보호한다.
+
+- `main` direct push 금지
+- `main` 삭제 금지
+- force push 금지
+- `main` 변경은 PR 필수
+- PR 승인 1명 이상 필수
+- admin bypass는 `pull_request` 모드만 허용한다.
+
+control-plane repo 자체를 수정할 때도 `main`에 직접 push하지 않는다.
+역할 접두사 branch에서 작업하고 PR로 올린다.
+
 ## Target Repo 브랜치 운영 기준
 
 target repo를 처음 remote에 올릴 때는 아래 순서를 기본으로 한다.

--- a/tests/test_gitignore_whitelist.py
+++ b/tests/test_gitignore_whitelist.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_tracked_files_are_whitelisted_from_default_ignore():
+    ls_files = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    blocked = []
+    for path in ls_files.stdout.splitlines():
+        ignored = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(REPO_ROOT),
+                "check-ignore",
+                "--no-index",
+                "-v",
+                "--",
+                path,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if ignored.returncode != 0 or not ignored.stdout.strip():
+            continue
+
+        pattern = ignored.stdout.split("\t", 1)[0].rsplit(":", 1)[-1]
+        if not pattern.startswith("!"):
+            blocked.append(f"{path} matched {pattern}")
+
+    assert blocked == []


### PR DESCRIPTION
## change id

- not-issued: control-plane ruleset sync and PR flow verification

## 관련 issue

- none

## 대상 repo/service

- `clever-agent-project`
- control-plane startup and bootstrap documentation

## 변경 내용

- Document the current public control-plane repo protection contract.
- Record that `main` is protected by `CLEVER protect main`.
- Add the actual PR template with CLEVER PR review completion fields.
- Whitelist `.github/PULL_REQUEST_TEMPLATE.md` so the PR template does not require force-add.
- Add a regression test that fails when tracked required files are only matched by the catch-all ignore rule.

## companion PRs

- https://github.com/EVNSolution/clever-context-monorepo/pull/4
- https://github.com/EVNSolution/clever-change-control/pull/14

## 테스트 여부

- `git push origin HEAD:main` rejected with `GH013` and `Changes must be made through a pull request`.
- `git diff --check`
- `git diff --cached --check`
- `python3 -m pytest` -> 43 passed, 2 skipped
- `git check-ignore --no-index -v .github/PULL_REQUEST_TEMPLATE.md` -> matched `!/.github/PULL_REQUEST_TEMPLATE.md`

## 검수 포인트

- Branch name uses the role prefix `docs/`.
- `main` direct push is blocked.
- PR body carries the review-agent completion fields.
- `.github/PULL_REQUEST_TEMPLATE.md` is in the repository whitelist.

## rollout/rollback 영향

- docs/template/test only
- no runtime or deployment impact

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `README.md`, `AGENTS.md`, `docs/setting.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.gitignore`, `tests/test_gitignore_whitelist.py`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: https://github.com/EVNSolution/clever-context-monorepo/pull/4
- linked issue close evidence: no linked issue for this ruleset smoke test
