### PR TITLE
docs: add PR merge title standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -403,6 +403,25 @@ When the agent bootstraps or confirms a target repo, it should preserve this mea
 
 If local branch protection is requested or available, prefer a repo-local `pre-push` guard for `main`.
 
+## PR Merge Commit Title Contract
+
+When merging a PR into `main`, make the resulting main commit visibly PR-based.
+Use squash merge and set the merge subject explicitly:
+
+```bash
+gh pr merge <pr-number> --squash \
+  --subject "PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>" \
+  --body-file <merge-body-file>
+```
+
+Merge body should include:
+
+- merge summary
+- validation evidence
+- wiki/service context update result
+
+Do not use a plain feature/doc commit title as the main merge commit subject.
+
 ## What Not To Do
 
 Do not:

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ ruleset 기반으로 `main`/`dev` direct push를 막고 PR 필수 정책을 쓰�
 - merge/write는 repo admin 권한자만 수행
 - admin bypass는 `pull_request` 모드만 허용
 
+`main` merge commit 제목은 PR merge임이 드러나게 아래 형식을 쓴다.
+
+```text
+PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>
+```
+
 ### 세션 시작
 
 generic CLEVER startup은 `clever-agent-project`에서 시작한다.


### PR DESCRIPTION
## change id

- not-issued: control-plane merge title standard

## 관련 issue

- none

## 대상 repo/service

- `clever-agent-project`
- control-plane startup and agent operating contract

## 변경 내용

- Add the PR merge commit title contract.
- Standardize main merge subject format as `PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>`.
- Document merge body requirements.

## companion PRs

- https://github.com/EVNSolution/clever-context-monorepo/pull/6
- https://github.com/EVNSolution/clever-change-control/pull/16

## 테스트 여부

- `git diff --check`
- `python3 -m pytest` -> 43 passed, 2 skipped

## 검수 포인트

- Main merge commit should visibly look like a PR merge.
- The merge subject should include repo and PR number.

## rollout/rollback 영향

- docs only
- no runtime or deployment impact

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `AGENTS.md`, `README.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: https://github.com/EVNSolution/clever-context-monorepo/pull/6
- linked issue close evidence: no linked issue for this merge-title standard update
