### PR TITLE
docs: use default merge pull request title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@
 !/tests/test_concurrent_work_gate.py
 !/tests/test_gitignore_whitelist.py
 !/tests/test_issue_resolution_context_wiki_prompt.py
+!/tests/test_merge_title_standard.py
 !/tests/test_sync_issue_from_md.py
 
 # Defense in depth for common local artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,15 +434,16 @@ If local branch protection is requested or available, prefer a repo-local `pre-p
 ## PR Merge Commit Title Contract
 
 When merging a PR into `main`, make the resulting main commit visibly PR-based.
-Use squash merge and set the merge subject explicitly:
+Use the GitHub default-style merge subject. If the agent uses squash merge,
+set the subject explicitly:
 
 ```bash
 gh pr merge <pr-number> --squash \
-  --subject "PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>" \
+  --subject "Merge pull request #<pr-number> from <owner>/<source-branch>" \
   --body-file <merge-body-file>
 ```
 
-Merge body should include:
+Merge body should start with the PR title, then include:
 
 - merge summary
 - validation evidence

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ ruleset 기반으로 `main`/`dev` direct push를 막고 PR 필수 정책을 쓰�
 `main` merge commit 제목은 PR merge임이 드러나게 아래 형식을 쓴다.
 
 ```text
-PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>
+Merge pull request #<pr-number> from <owner>/<source-branch>
 ```
 
 ### 세션 시작

--- a/tests/test_merge_title_standard.py
+++ b/tests/test_merge_title_standard.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTEXT_ROOT = REPO_ROOT.parent / "clever-context-monorepo"
+CHANGE_CONTROL_ROOT = REPO_ROOT.parent / "clever-change-control"
+
+DEFAULT_MERGE_SUBJECT = "Merge pull request #<pr-number> from <owner>/<source-branch>"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_merge_title_standard_uses_github_default_prefix():
+    docs = [
+        read(REPO_ROOT / "AGENTS.md"),
+        read(REPO_ROOT / "README.md"),
+        read(CONTEXT_ROOT / "AGENTS.md"),
+        read(CONTEXT_ROOT / "README.md"),
+        read(CONTEXT_ROOT / "docs/root/pipeline-governance.md"),
+        read(CHANGE_CONTROL_ROOT / "AGENTS.md"),
+        read(CHANGE_CONTROL_ROOT / "README.md"),
+    ]
+
+    for text in docs:
+        assert "PR-MERGE" not in text
+        assert DEFAULT_MERGE_SUBJECT in text


### PR DESCRIPTION
## change id

- not-issued: control-plane merge title adjustment

## 관련 issue

- none

## 대상 repo/service

- `clever-agent-project`
- merge title operating contract

## 변경 내용

- Replace the custom `PR-MERGE` subject standard with the GitHub default-style `Merge pull request #<pr-number> from <owner>/<source-branch>` subject.
- Add regression coverage so control-plane docs do not reintroduce `PR-MERGE`.

## 테스트 여부

- `python3 -m pytest` -> 47 passed, 2 skipped
- `git diff --check`

## 검수 포인트

- The merge subject starts like GitHub's default merge commit title.
- The PR title is kept in the merge body rather than forced into the subject prefix.

## rollout/rollback 영향

- docs/tests only
- no runtime or deployment impact

## Concurrent Work Gate

- parallel work decision: `allowed-with-non-overlap`
- target repo issue: none for control-plane doc update
- clever-change-control issue: none for control-plane doc update
- open PR checked: companion PRs only
- conflict candidates: none; each PR writes separate control-plane repo files
- user-forced-proceed reason: not used

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `AGENTS.md`, `README.md`, `tests/test_merge_title_standard.py`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: companion PR will be linked after creation
- linked issue close evidence: no linked issue for this control-plane doc update
