### PR TITLE
feat: add startup preflight gate

### DIFF
--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -11,13 +11,14 @@ Use this skill as the single entry point for new CLEVER work.
 
 It forces the same start sequence for every user and every repo:
 
-1. Read the two SSOT repos first.
-2. Collect the startup branch.
-3. If it is MSA-oriented and service-specific, determine the target service by conversation and read the relevant root/service docs.
-4. Infer the work context from the current repo.
-5. Convert the request into a `project-start` draft packet.
-6. Ask for one final approval.
-7. Only then create the root issue, propose repo bootstrap, seed the target repo, clone the repo, and hand off.
+1. Run the preflight gate.
+2. Read the two SSOT repos first.
+3. Collect the startup branch.
+4. If it is MSA-oriented and service-specific, determine the target service by conversation and read the relevant root/service docs.
+5. Infer the work context from the current repo.
+6. Convert the request into a `project-start` draft packet.
+7. Ask for one final approval.
+8. Only then create the root issue, propose repo bootstrap, seed the target repo, clone the repo, and hand off.
 
 **Core principle:** do not start CLEVER work from a freeform prompt when the SSOT repos are available.
 
@@ -32,24 +33,33 @@ Do not put the project planning draft into `AGENTS.md`.
 
 ## First-Response Hard Gate
 
-Before showing the first-response template, automatically inspect the local workspace:
+Before showing the first-response template, automatically inspect the local workspace,
+`gh auth status`, GitHub account, remotes, repo visibility, and issue/PR/ruleset read access:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 If the session is explicitly about editing the current control-plane repo itself, run:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
 Interpret the result like this:
 
-- `agent_action=proceed-with-hard-gate`: continue in the current session
-- `agent_action=current-repo-maintenance`: stay in the current control-plane repo and treat it as the target
-- `agent_action=switch-to-clever-agent-project`: move startup to `clever-agent-project` first
-- `agent_action=stop-and-fix-workspace`: stop and clearly state that the local three-repository workspace is incomplete
+- `preflight_check.ready=false`: stop and show the failed checks before asking startup questions.
+- `preflight_check.ready=true`: continue by reading `workspace_check.agent_action`.
+- `workspace_check.agent_action=proceed-with-hard-gate`: continue in the current session
+- `workspace_check.agent_action=current-repo-maintenance`: stay in the current control-plane repo and treat it as the target
+- `workspace_check.agent_action=switch-to-clever-agent-project`: move startup to `clever-agent-project` first
+- `workspace_check.agent_action=stop-and-fix-workspace`: stop and clearly state that the local three-repository workspace is incomplete
+
+The expected GitHub login defaults to `OziinG`.
+Use `CLEVER_EXPECTED_GITHUB_LOGIN` or `--expected-github-login` only when the user explicitly authorizes another account.
+Preflight also checks active `EVNSolution` org membership. Repository creation
+permission cannot be proven without the actual `gh repo create` write attempt,
+so treat that command's success as the creation proof after preflight passes.
 
 Before planning, implementation, `project-start` creation, or repo bootstrap, the agent must first normalize the session into the same opening structure.
 
@@ -303,6 +313,8 @@ Once the user approves:
 7. Apply or confirm the branch operating contract in the target repo:
    - initial remote bootstrap commit may land on `main`
    - immediately after that, create and push `dev`
+   - before applying rulesets or repository protection settings, run:
+     `python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --admin-preflight --target-repo-full-name <owner>/<repo> --json`
    - after `dev` exists, run `scripts/apply-github-rulesets.sh <owner>/<repo>` when GitHub Administration write permission is available
    - GitHub rulesets should target only `main` and `dev`: both require PR-only updates with `required_approving_review_count=0`, and other branches stay unrestricted by ruleset
    - after `dev` exists, block direct local pushes to `main`

--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -61,6 +61,16 @@ Preflight also checks active `EVNSolution` org membership. Repository creation
 permission cannot be proven without the actual `gh repo create` write attempt,
 so treat that command's success as the creation proof after preflight passes.
 
+## PR 완료 후 branch 정리
+
+After a PR is merged, delete the source task branch only when there is no other
+open PR using that branch. `main`과 `dev`는 삭제 대상이 아니다.
+
+```bash
+git push origin --delete <source-branch>
+git branch -d <source-branch>
+```
+
 Before planning, implementation, `project-start` creation, or repo bootstrap, the agent must first normalize the session into the same opening structure.
 
 Use this exact first-response template:
@@ -435,6 +445,32 @@ Rules:
 - a PR into `dev` or `main` must finish review-agent work with wiki/service context updates, or a documented not-needed decision
 - do not upload PR information to the wiki; update only service, operational, contract, or navigation context
 - issue close should refer to the PR review completion result instead of duplicating the context/wiki decision
+
+## PR Branch Cleanup
+
+PR 완료 후 branch 정리:
+
+After a PR is merged, or closed with the source branch intentionally abandoned,
+clean up the task branch unless it still has an open PR, linked follow-up issue,
+child branch, or active release/hotfix use.
+
+Default command sequence:
+
+```bash
+git switch dev
+git pull --ff-only origin dev
+git branch -d <source-branch>
+git push origin --delete <source-branch>
+git fetch --prune origin
+```
+
+- `main`과 `dev`는 삭제 대상이 아니다.
+- Use `git branch -d <source-branch>` by default.
+- Use `git branch -D <source-branch>` only when the PR was closed without merge
+  and the user explicitly confirms the branch can be discarded.
+- Do not delete a remote branch if it still backs an open PR, follow-up issue,
+  child branch, or active release/hotfix.
+- If GitHub already deleted the remote branch, still run `git fetch --prune origin`.
 
 ## Common Mistakes
 

--- a/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
+++ b/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -42,6 +44,8 @@ ALLOWED_UI_IMPACTS = {
     "있음",
     "없음",
 }
+DEFAULT_GITHUB_OWNER = "EVNSolution"
+DEFAULT_EXPECTED_GITHUB_LOGIN = "OziinG"
 
 CONTEXT_DOCS = [
     "README.md",
@@ -127,18 +131,32 @@ TARGET_REPO_SEED_FILES = [
 ]
 
 
-def run_command(cmd: list[str], cwd: Path | None = None) -> str | None:
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_command_result(cmd: list[str], cwd: Path | None = None) -> CommandResult:
     try:
         proc = subprocess.run(
             cmd,
             cwd=str(cwd) if cwd else None,
-            check=True,
+            check=False,
             text=True,
             capture_output=True,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except FileNotFoundError as exc:
+        return CommandResult(127, "", str(exc))
+    return CommandResult(proc.returncode, proc.stdout, proc.stderr)
+
+
+def run_command(cmd: list[str], cwd: Path | None = None) -> str | None:
+    result = run_command_result(cmd, cwd=cwd)
+    if result.returncode != 0:
         return None
-    return proc.stdout.strip()
+    return result.stdout.strip()
 
 
 def current_branch(repo_path: Path) -> str | None:
@@ -347,6 +365,382 @@ def build_workspace_check(start: Path, *, current_repo_maintenance: bool = False
         "agent_action": action,
         "message": message,
         "repos": repos,
+    }
+
+
+def add_preflight_check(
+    checks: list[dict[str, Any]],
+    *,
+    name: str,
+    passed: bool,
+    message: str,
+    details: dict[str, Any] | None = None,
+) -> None:
+    check: dict[str, Any] = {
+        "name": name,
+        "status": "pass" if passed else "fail",
+        "message": message,
+    }
+    if details:
+        check["details"] = details
+    checks.append(check)
+
+
+def command_message(result: CommandResult) -> str:
+    output = (result.stderr or result.stdout).strip()
+    return output if output else f"command exited with {result.returncode}"
+
+
+def parse_json_object(raw: str) -> dict[str, Any] | None:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def normalize_repo_full_name(repo: str | None, *, github_owner: str) -> str | None:
+    if not repo:
+        return None
+    return repo if "/" in repo else f"{github_owner}/{repo}"
+
+
+def collect_control_plane_paths(workspace_check: dict[str, Any]) -> dict[str, Path]:
+    paths: dict[str, Path] = {}
+    repos = workspace_check.get("repos", {})
+    for repo_name_value in CONTROL_PLANE_REPOS:
+        repo_state = repos.get(repo_name_value, {})
+        checkout_path = repo_state.get("checkout_path")
+        if checkout_path:
+            paths[repo_name_value] = Path(checkout_path)
+    return paths
+
+
+def build_preflight_check(
+    *,
+    cwd: Path,
+    expected_github_login: str = DEFAULT_EXPECTED_GITHUB_LOGIN,
+    github_owner: str = DEFAULT_GITHUB_OWNER,
+    admin: bool = False,
+    target_repo_full_name: str | None = None,
+    current_repo_maintenance: bool = False,
+) -> dict[str, Any]:
+    mode = "admin" if admin else "basic"
+    checks: list[dict[str, Any]] = []
+
+    git_path = shutil.which("git")
+    add_preflight_check(
+        checks,
+        name="git-cli",
+        passed=bool(git_path),
+        message=git_path or "git CLI is required before CLEVER startup.",
+    )
+
+    gh_path = shutil.which("gh")
+    add_preflight_check(
+        checks,
+        name="gh-cli",
+        passed=bool(gh_path),
+        message=gh_path or "GitHub CLI is required. Run `gh auth login` after installing gh.",
+    )
+
+    gh_auth_ok = False
+    github_login: str | None = None
+    if gh_path:
+        auth_result = run_command_result(["gh", "auth", "status"])
+        gh_auth_ok = auth_result.returncode == 0
+        add_preflight_check(
+            checks,
+            name="gh-auth",
+            passed=gh_auth_ok,
+            message=(
+                "`gh auth status` passed."
+                if gh_auth_ok
+                else f"`gh auth status` failed: {command_message(auth_result)}"
+            ),
+        )
+
+        user_result = run_command_result(["gh", "api", "user", "--jq", ".login"])
+        github_login = user_result.stdout.strip() if user_result.returncode == 0 else None
+        login_ok = github_login == expected_github_login
+        add_preflight_check(
+            checks,
+            name="github-account",
+            passed=login_ok,
+            message=(
+                f"GitHub account is {github_login}."
+                if login_ok
+                else (
+                    "Expected GitHub account "
+                    f"{expected_github_login}, got {github_login or command_message(user_result)}."
+                )
+            ),
+            details={
+                "expected": expected_github_login,
+                "actual": github_login,
+            },
+        )
+        membership_result = run_command_result(
+            ["gh", "api", f"user/memberships/orgs/{github_owner}"]
+        )
+        membership_info = parse_json_object(membership_result.stdout)
+        membership_ok = (
+            membership_result.returncode == 0
+            and membership_info is not None
+            and membership_info.get("state") == "active"
+        )
+        add_preflight_check(
+            checks,
+            name="github-org-membership",
+            passed=membership_ok,
+            message=(
+                f"GitHub account is an active member of {github_owner}."
+                if membership_ok
+                else (
+                    f"Cannot confirm active {github_owner} org membership: "
+                    f"{command_message(membership_result)}"
+                )
+            ),
+            details={
+                "org": github_owner,
+                "state": membership_info.get("state") if membership_info else None,
+                "role": membership_info.get("role") if membership_info else None,
+            },
+        )
+    else:
+        add_preflight_check(
+            checks,
+            name="gh-auth",
+            passed=False,
+            message="Cannot run `gh auth status` because gh CLI is missing.",
+        )
+        add_preflight_check(
+            checks,
+            name="github-account",
+            passed=False,
+            message=f"Cannot confirm expected GitHub account {expected_github_login}.",
+            details={"expected": expected_github_login, "actual": None},
+        )
+        add_preflight_check(
+            checks,
+            name="github-org-membership",
+            passed=False,
+            message=f"Cannot confirm {github_owner} org membership because gh CLI is missing.",
+            details={"org": github_owner, "state": None, "role": None},
+        )
+
+    workspace_check = build_workspace_check(
+        cwd,
+        current_repo_maintenance=current_repo_maintenance,
+    )
+    workspace_ok = bool(workspace_check.get("startup_ready"))
+    add_preflight_check(
+        checks,
+        name="workspace",
+        passed=workspace_ok,
+        message=workspace_check.get("message", "workspace check completed"),
+        details={
+            "agent_action": workspace_check.get("agent_action"),
+            "control_plane_complete": workspace_check.get("control_plane_complete"),
+        },
+    )
+
+    control_paths = collect_control_plane_paths(workspace_check)
+
+    remote_messages: list[str] = []
+    remote_ok = len(control_paths) == len(CONTROL_PLANE_REPOS)
+    for repo_name_value in CONTROL_PLANE_REPOS:
+        repo_path = control_paths.get(repo_name_value)
+        expected_full_name = f"{github_owner}/{repo_name_value}"
+        actual_full_name = repo_full_name(repo_path) if repo_path else None
+        if actual_full_name != expected_full_name:
+            remote_ok = False
+            remote_messages.append(
+                f"{repo_name_value}: expected {expected_full_name}, got {actual_full_name or 'missing'}"
+            )
+    add_preflight_check(
+        checks,
+        name="control-plane-remotes",
+        passed=remote_ok,
+        message=(
+            f"All control-plane remotes point to {github_owner}."
+            if remote_ok
+            else "; ".join(remote_messages)
+        ),
+    )
+
+    clean_messages: list[str] = []
+    clean_ok = len(control_paths) == len(CONTROL_PLANE_REPOS)
+    for repo_name_value, repo_path in control_paths.items():
+        result = run_command_result(["git", "-C", str(repo_path), "status", "--short"])
+        if result.returncode != 0 or result.stdout.strip():
+            clean_ok = False
+            clean_messages.append(
+                f"{repo_name_value}: {command_message(result) if result.returncode != 0 else result.stdout.strip()}"
+            )
+    add_preflight_check(
+        checks,
+        name="control-plane-worktrees-clean",
+        passed=clean_ok,
+        message=(
+            "All control-plane worktrees are clean."
+            if clean_ok
+            else "; ".join(clean_messages or ["control-plane checkout is incomplete"])
+        ),
+    )
+
+    fetch_messages: list[str] = []
+    fetch_ok = len(control_paths) == len(CONTROL_PLANE_REPOS)
+    for repo_name_value, repo_path in control_paths.items():
+        result = run_command_result(["git", "-C", str(repo_path), "fetch", "--dry-run", "origin"])
+        if result.returncode != 0:
+            fetch_ok = False
+            fetch_messages.append(f"{repo_name_value}: {command_message(result)}")
+    add_preflight_check(
+        checks,
+        name="control-plane-remote-fetch",
+        passed=fetch_ok,
+        message=(
+            "All control-plane remotes are reachable."
+            if fetch_ok
+            else "; ".join(fetch_messages or ["control-plane checkout is incomplete"])
+        ),
+    )
+
+    repo_access_messages: list[str] = []
+    issue_pr_messages: list[str] = []
+    ruleset_messages: list[str] = []
+    repo_access_ok = bool(gh_path) and len(control_paths) == len(CONTROL_PLANE_REPOS)
+    issue_pr_ok = bool(gh_path) and len(control_paths) == len(CONTROL_PLANE_REPOS)
+    ruleset_ok = bool(gh_path) and len(control_paths) == len(CONTROL_PLANE_REPOS)
+    for repo_name_value in CONTROL_PLANE_REPOS:
+        expected_full_name = f"{github_owner}/{repo_name_value}"
+        view_result = run_command_result(
+            [
+                "gh",
+                "repo",
+                "view",
+                expected_full_name,
+                "--json",
+                "nameWithOwner,visibility,isPrivate,viewerPermission",
+            ]
+        )
+        repo_info = parse_json_object(view_result.stdout)
+        if view_result.returncode != 0 or not repo_info:
+            repo_access_ok = False
+            repo_access_messages.append(f"{expected_full_name}: {command_message(view_result)}")
+        elif repo_info.get("visibility") != "PUBLIC" or repo_info.get("isPrivate"):
+            repo_access_ok = False
+            repo_access_messages.append(f"{expected_full_name}: repository must be PUBLIC")
+
+        for issue_or_pr in ("issue", "pr"):
+            list_result = run_command_result(
+                [
+                    "gh",
+                    issue_or_pr,
+                    "list",
+                    "--repo",
+                    expected_full_name,
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number",
+                ]
+            )
+            if list_result.returncode != 0:
+                issue_pr_ok = False
+                issue_pr_messages.append(f"{expected_full_name} {issue_or_pr}: {command_message(list_result)}")
+
+        ruleset_result = run_command_result(["gh", "api", f"repos/{expected_full_name}/rulesets"])
+        if ruleset_result.returncode != 0:
+            ruleset_ok = False
+            ruleset_messages.append(f"{expected_full_name}: {command_message(ruleset_result)}")
+
+    add_preflight_check(
+        checks,
+        name="github-repo-access",
+        passed=repo_access_ok,
+        message=(
+            "All control-plane GitHub repos are readable and public."
+            if repo_access_ok
+            else "; ".join(repo_access_messages or ["gh CLI is unavailable or workspace is incomplete"])
+        ),
+    )
+    add_preflight_check(
+        checks,
+        name="github-issue-pr-access",
+        passed=issue_pr_ok,
+        message=(
+            "Issues and PRs are readable for every control-plane repo."
+            if issue_pr_ok
+            else "; ".join(issue_pr_messages or ["gh CLI is unavailable or workspace is incomplete"])
+        ),
+    )
+    add_preflight_check(
+        checks,
+        name="ruleset-read",
+        passed=ruleset_ok,
+        message=(
+            "Rulesets are readable for every control-plane repo."
+            if ruleset_ok
+            else "; ".join(ruleset_messages or ["gh CLI is unavailable or workspace is incomplete"])
+        ),
+    )
+
+    normalized_target_repo = normalize_repo_full_name(
+        target_repo_full_name,
+        github_owner=github_owner,
+    )
+    if admin:
+        target_admin_ok = False
+        target_admin_message = "--admin-preflight requires --target-repo or --target-repo-full-name."
+        if normalized_target_repo:
+            view_result = run_command_result(
+                [
+                    "gh",
+                    "repo",
+                    "view",
+                    normalized_target_repo,
+                    "--json",
+                    "nameWithOwner,visibility,isPrivate,viewerPermission",
+                ]
+            )
+            repo_info = parse_json_object(view_result.stdout)
+            if view_result.returncode != 0 or not repo_info:
+                target_admin_message = (
+                    f"{normalized_target_repo}: cannot confirm admin permission: "
+                    f"{command_message(view_result)}"
+                )
+            else:
+                permission = repo_info.get("viewerPermission")
+                is_public = repo_info.get("visibility") == "PUBLIC" and not repo_info.get("isPrivate")
+                target_admin_ok = permission == "ADMIN" and is_public
+                target_admin_message = (
+                    f"{normalized_target_repo}: ADMIN permission and PUBLIC visibility confirmed."
+                    if target_admin_ok
+                    else (
+                        f"{normalized_target_repo}: expected PUBLIC repo with ADMIN permission, "
+                        f"got visibility={repo_info.get('visibility')} permission={permission}."
+                    )
+                )
+        add_preflight_check(
+            checks,
+            name="target-repo-admin",
+            passed=target_admin_ok,
+            message=target_admin_message,
+            details={"target_repo": normalized_target_repo},
+        )
+
+    ready = all(check["status"] == "pass" for check in checks)
+    return {
+        "mode": mode,
+        "ready": ready,
+        "expected_github_login": expected_github_login,
+        "github_login": github_login,
+        "github_owner": github_owner,
+        "target_repo": normalized_target_repo,
+        "workspace_check": workspace_check,
+        "checks": checks,
     }
 
 
@@ -701,6 +1095,30 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cwd", default=os.getcwd(), help="Working directory to inspect")
     parser.add_argument("--user-session", default=os.environ.get("USER", "unknown-session"))
     parser.add_argument(
+        "--preflight",
+        action="store_true",
+        help="Run the strict startup preflight gate before project-start work.",
+    )
+    parser.add_argument(
+        "--admin-preflight",
+        action="store_true",
+        help="Run startup preflight plus target repo admin checks before repo/ruleset changes.",
+    )
+    parser.add_argument(
+        "--expected-github-login",
+        default=os.environ.get("CLEVER_EXPECTED_GITHUB_LOGIN", DEFAULT_EXPECTED_GITHUB_LOGIN),
+        help="Expected GitHub login for gh authenticated operations.",
+    )
+    parser.add_argument(
+        "--github-owner",
+        default=os.environ.get("CLEVER_GITHUB_OWNER", DEFAULT_GITHUB_OWNER),
+        help="GitHub owner or organization expected for CLEVER repositories.",
+    )
+    parser.add_argument(
+        "--target-repo-full-name",
+        help="Target repo full name for admin preflight, for example EVNSolution/example.",
+    )
+    parser.add_argument(
         "--workspace-check",
         action="store_true",
         help="Inspect the local three-repository workspace and report startup readiness.",
@@ -777,6 +1195,21 @@ def print_workspace_check(workspace_check: dict[str, Any]) -> None:
             print(f"- {item}")
     print(f"recommended-start-repo: {workspace_check['recommended_start_repo']}")
     print("WORKSPACE_CHECK_END")
+
+
+def print_preflight_check(preflight_check: dict[str, Any]) -> None:
+    print("PREFLIGHT_CHECK_BEGIN")
+    print(f"mode: {preflight_check['mode']}")
+    print(f"ready: {'yes' if preflight_check['ready'] else 'no'}")
+    print(f"github-owner: {preflight_check['github_owner']}")
+    print(f"expected-github-login: {preflight_check['expected_github_login']}")
+    print(f"github-login: {preflight_check['github_login'] or 'unknown'}")
+    if preflight_check.get("target_repo"):
+        print(f"target-repo: {preflight_check['target_repo']}")
+    print("checks:")
+    for check in preflight_check["checks"]:
+        print(f"- {check['name']}: {check['status']} - {check['message']}")
+    print("PREFLIGHT_CHECK_END")
 
 
 def print_text_packet(packet: dict[str, Any]) -> None:
@@ -863,6 +1296,22 @@ def main() -> int:
         cwd,
         current_repo_maintenance=args.current_repo_maintenance,
     )
+
+    if args.preflight or args.admin_preflight:
+        target_repo_for_admin = args.target_repo_full_name or args.target_repo
+        preflight_check = build_preflight_check(
+            cwd=cwd,
+            expected_github_login=args.expected_github_login,
+            github_owner=args.github_owner,
+            admin=args.admin_preflight,
+            target_repo_full_name=target_repo_for_admin,
+            current_repo_maintenance=args.current_repo_maintenance,
+        )
+        if args.json:
+            print(json.dumps({"preflight_check": preflight_check}, ensure_ascii=False, indent=2))
+        else:
+            print_preflight_check(preflight_check)
+        return 0 if preflight_check["ready"] else 3
 
     if args.workspace_check:
         if args.json:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,24 +19,55 @@ If any of these repositories are missing, the workspace is incomplete.
 Do not pretend web links are a substitute for local context.
 Stop and state that the three-repository local workspace is required.
 
-At startup, run this automatic check first:
+At startup, run this automatic preflight first:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 If the session is explicitly about editing the current control-plane repo itself, run:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
-Use the returned `agent_action` field as the startup branch:
+The preflight must verify at least:
+
+- local `git` and `gh` CLIs
+- `gh auth status`
+- authenticated GitHub login, defaulting to `OziinG`
+- active membership in the `EVNSolution` GitHub org
+- local three-repository workspace readiness
+- control-plane origin remotes under `EVNSolution/*`
+- clean control-plane worktrees
+- remote fetch access
+- GitHub repo visibility and issue/PR/ruleset read access
+
+If `preflight_check.ready` is false, stop before startup questions and report the
+failed checks.
+
+If it is true, use the returned `workspace_check.agent_action` field as the
+startup branch:
 
 - `proceed-with-hard-gate`
 - `current-repo-maintenance`
 - `switch-to-clever-agent-project`
 - `stop-and-fix-workspace`
+
+Before creating a target repo, applying rulesets, or changing GitHub protection
+settings, run admin preflight with the target repo:
+
+```bash
+python3 scripts/bootstrap_clever_work.py \
+  --cwd "$PWD" \
+  --admin-preflight \
+  --target-repo-full-name EVNSolution/<target-repo> \
+  --json
+```
+
+Repository creation permission cannot be proven without the actual write attempt.
+Treat org membership and token/API access as the pre-create gate, then treat
+`gh repo create` success as the creation proof.
 
 ## Clone-Ready Startup Contract
 
@@ -49,11 +80,14 @@ conversation if the answers are not already present.
 First action:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 Then apply the result:
 
+- `preflight_check.ready=false`: show failed checks and stop before asking
+  project-start questions.
+- `preflight_check.ready=true`: read `workspace_check.agent_action` and continue.
 - `proceed-with-hard-gate`: 작업 시작 질문을 남긴다.
 - `switch-to-clever-agent-project`: tell the user to reopen or continue from
   `clever-agent-project`, then 작업 시작 질문을 남긴다.
@@ -466,7 +500,7 @@ Do not:
 
 The expected operating flow is:
 
-1. Verify the three-repository local workspace
+1. Run preflight for the three-repository local workspace and GitHub account
 2. Gather the startup frame
    - collect `work_kind`, `architecture_kind`, `session_goal`
    - fill the startup branch state template

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,16 @@ Repository creation permission cannot be proven without the actual write attempt
 Treat org membership and token/API access as the pre-create gate, then treat
 `gh repo create` success as the creation proof.
 
+## PR 완료 후 branch 정리
+
+PR merge가 끝나고 source branch에 open PR이 더 없으면 remote/local task branch를 정리한다.
+`main`과 `dev`는 삭제 대상이 아니다.
+
+```bash
+git push origin --delete <source-branch>
+git branch -d <source-branch>
+```
+
 ## Clone-Ready Startup Contract
 
 This section exists for a fresh clone of `clever-agent-project`.
@@ -484,6 +494,32 @@ Merge body should start with the PR title, then include:
 - wiki/service context update result
 
 Do not use a plain feature/doc commit title as the main merge commit subject.
+
+## PR Branch Cleanup Contract
+
+PR 완료 후 branch 정리:
+
+After a PR is merged, or closed with the source branch intentionally abandoned,
+clean up the task branch unless it still has an open PR, linked follow-up issue,
+child branch, or active release/hotfix use.
+
+Default command sequence:
+
+```bash
+git switch dev
+git pull --ff-only origin dev
+git branch -d <source-branch>
+git push origin --delete <source-branch>
+git fetch --prune origin
+```
+
+- `main`과 `dev`는 삭제 대상이 아니다.
+- Use `git branch -d <source-branch>` by default.
+- Use `git branch -D <source-branch>` only when the PR was closed without merge
+  and the user explicitly confirms the branch can be discarded.
+- Do not delete a remote branch if it still backs an open PR, follow-up issue,
+  child branch, or active release/hotfix.
+- If GitHub already deleted the remote branch, still run `git fetch --prune origin`.
 
 ## What Not To Do
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ git clone https://github.com/EVNSolution/clever-context-monorepo.git
 git clone https://github.com/EVNSolution/clever-change-control.git
 
 cd clever-agent-project
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 에이전트 종류별 실행 예시:
@@ -131,26 +131,44 @@ CLEVER를 제대로 실행하려면 아래 조건이 먼저 만족되어야 한�
 - 에이전트가 세 레포의 로컬 파일을 직접 읽을 수 있어야 한다.
 - 웹 링크만으로는 충분하지 않다.
 - 3개 중 하나라도 없으면 실행 품질이 크게 저하된다.
+- `gh` CLI가 설치되어 있고 `gh auth status`가 통과해야 한다.
+- 기본 GitHub 계정은 `OziinG`으로 검증한다. 다른 계정을 써야 하면 `CLEVER_EXPECTED_GITHUB_LOGIN` 또는 `--expected-github-login`으로 명시한다.
+- GitHub 계정이 `EVNSolution` org active member인지 확인한다.
+- 세 control-plane repo의 origin은 `EVNSolution/*`이어야 한다.
+- 세 control-plane repo는 public이어야 하고 issue, PR, ruleset 조회가 가능해야 한다.
 
 즉, 현재 CLEVER는 **단일 레포 런타임이 아니라 3레포 로컬 워크스페이스 런타임**이다.
 
 ## 운영 세부 기준
 
-### 워크스페이스 확인
+### Preflight Gate
 
-세션을 시작하기 전에 에이전트는 아래 명령으로 로컬 3레포 상태를 자동 감지할 수 있다.
+세션을 시작하기 전에 에이전트는 아래 명령으로 로컬 3레포, `gh auth status`, GitHub 계정, 원격 접근, issue/PR/ruleset 조회 가능 여부를 자동 감지한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 현재 control-plane 저장소 자체를 직접 수정하는 세션이면 아래처럼 유지보수 모드로 확인한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
-반환된 `agent_action`이 `proceed-with-hard-gate`면 그대로 시작 템플릿으로 진행하고, `current-repo-maintenance`면 현재 control-plane 저장소를 직접 수정하는 세션으로 보고 여기서 계속하며, `switch-to-clever-agent-project`면 시작 위치를 옮기고, `stop-and-fix-workspace`면 누락된 레포를 먼저 보완한다.
+반환된 `preflight_check.ready`가 `false`면 시작 템플릿으로 내려가지 않는다.
+`true`이면 내부 `workspace_check.agent_action`을 읽는다.
+`proceed-with-hard-gate`면 그대로 시작 템플릿으로 진행하고, `current-repo-maintenance`면 현재 control-plane 저장소를 직접 수정하는 세션으로 보고 여기서 계속하며, `switch-to-clever-agent-project`면 시작 위치를 옮기고, `stop-and-fix-workspace`면 누락된 레포를 먼저 보완한다.
+
+repo 생성, ruleset 적용, 보호 설정처럼 GitHub admin 권한이 필요한 작업 직전에는 대상 repo를 지정해 admin preflight를 다시 통과해야 한다.
+새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight는 org membership과 token/API 접근을 먼저 확인하고 실제 생성 성공은 `gh repo create` 결과로 확정한다.
+
+```bash
+python3 scripts/bootstrap_clever_work.py \
+  --cwd "$PWD" \
+  --admin-preflight \
+  --target-repo-full-name EVNSolution/<target-repo> \
+  --json
+```
 
 ### 새 프로젝트 repo visibility
 
@@ -191,7 +209,7 @@ generic CLEVER startup은 `clever-agent-project`에서 시작한다.
 - `clever-context-monorepo` 정본 문서/규칙 수정
 - `clever-change-control` issue template/traceability 규칙 수정
 
-이 경우에는 해당 레포에서 세션을 열 수 있지만, 먼저 `workspace-check`를 돌려 generic startup이 아니라 repo-local maintenance인지 확인한다.
+이 경우에는 해당 레포에서 세션을 열 수 있지만, 먼저 `preflight`를 돌려 generic startup이 아니라 repo-local maintenance인지 확인한다.
 
 운영 규칙은 아래와 같다.
 

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -216,6 +216,27 @@ private repo ruleset enforce가 필요하면 GitHub Team, GitHub Pro, 또는 Git
 
 즉 `dev`는 통합 작업선이고, task branch는 역할별 작업선이다.
 
+### PR 완료 후 branch 정리
+
+PR이 merge됐거나 source branch를 버리기로 하고 closed 처리된 뒤에는 task
+branch를 정리한다. 단, 해당 branch가 아직 open PR, 후속 issue, child branch,
+active release/hotfix에 쓰이면 삭제하지 않는다.
+
+기본 명령은 아래 순서다.
+
+```bash
+git switch dev
+git pull --ff-only origin dev
+git branch -d <source-branch>
+git push origin --delete <source-branch>
+git fetch --prune origin
+```
+
+- `main`과 `dev`는 삭제 대상이 아니다.
+- 기본은 `git branch -d <source-branch>`를 쓴다.
+- merge 없이 닫은 branch를 폐기해야 할 때만 사용자 확인 후 `git branch -D <source-branch>`를 쓴다.
+- remote branch가 GitHub에서 이미 삭제됐더라도 `git fetch --prune origin`으로 로컬 추적 branch를 정리한다.
+
 ### GitHub ruleset 적용
 
 새 target repo에는 seed file로 `scripts/apply-github-rulesets.sh`를 복사한다.
@@ -244,6 +265,16 @@ scripts/apply-github-rulesets.sh <owner>/<repo>
 
 이 작업에는 `gh auth status` 통과, GitHub login `OziinG`, `EVNSolution` org membership, target repo의 GitHub Administration write 권한이 필요하다.
 새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight는 membership과 API 접근을 먼저 확인하고 실제 생성 성공은 `gh repo create` 결과로 확정한다.
+
+### PR 완료 후 branch 정리
+
+PR merge가 끝나고 source branch에 open PR이 더 없으면 remote/local task branch를 정리한다.
+`main`과 `dev`는 삭제 대상이 아니다.
+
+```bash
+git push origin --delete <source-branch>
+git branch -d <source-branch>
+```
 
 ### 로컬 `main` push 금지 가드
 

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -84,6 +84,8 @@ gh auth status
 ```
 
 헤드리스 환경에서는 `GH_TOKEN` 환경 변수 또는 `gh auth login --with-token` 방식을 사용할 수 있다.
+CLEVER 기본 계정은 `OziinG`으로 검증한다. 다른 계정을 쓸 때는 `CLEVER_EXPECTED_GITHUB_LOGIN` 또는 `--expected-github-login`을 명시한다.
+preflight는 `EVNSolution` org active membership도 확인한다.
 
 ## Superpowers 설치
 
@@ -155,7 +157,7 @@ generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-project`에서 시�
 - `clever-context-monorepo` 정본 문서 수정
 - `clever-change-control` issue template 또는 traceability 규칙 수정
 
-이 경우에는 해당 레포에서 세션을 열 수 있지만, 먼저 `workspace-check`로 generic startup이 아니라 repo-local maintenance인지 확인해야 한다.
+이 경우에는 해당 레포에서 세션을 열 수 있지만, 먼저 `preflight`로 generic startup이 아니라 repo-local maintenance인지 확인해야 한다.
 
 즉 `superpowers`는 사용자 에이전트 환경에 설치되고, 새 프로젝트 repo는 그 환경 위에서 실행되는 작업 대상 repo가 된다.
 
@@ -173,7 +175,7 @@ generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-project`에서 시�
 - `main` 삭제 금지
 - force push 금지
 - `main` 변경은 PR 필수
-- PR 승인 1명 이상 필수
+- PR 승인 수는 0명
 - admin bypass는 `pull_request` 모드만 허용한다.
 
 control-plane repo 자체를 수정할 때도 `main`에 직접 push하지 않는다.
@@ -186,7 +188,7 @@ target repo를 처음 remote에 올릴 때는 아래 순서를 기본으로 한�
 1. 새 target repo는 public으로 생성한다.
 2. brand-new remote bootstrap이면 초기 commit은 `main`에 올릴 수 있다.
 3. 초기 remote publish가 끝나면 바로 `dev` branch를 만든다.
-4. `dev`가 push된 뒤 GitHub ruleset을 적용한다.
+4. `dev`가 push된 뒤 admin preflight를 통과하고 GitHub ruleset을 적용한다.
 5. 이후 일상 작업은 `dev` 또는 `dev`에서 파생된 task branch에서 한다.
 6. `dev`가 생긴 뒤에는 로컬에서 `main` direct push를 막는다.
 
@@ -217,7 +219,17 @@ private repo ruleset enforce가 필요하면 GitHub Team, GitHub Pro, 또는 Git
 ### GitHub ruleset 적용
 
 새 target repo에는 seed file로 `scripts/apply-github-rulesets.sh`를 복사한다.
-초기 `main` commit과 `dev` push가 끝난 뒤 아래처럼 실행한다.
+초기 `main` commit과 `dev` push가 끝난 뒤 먼저 admin preflight를 실행한다.
+
+```bash
+python3 scripts/bootstrap_clever_work.py \
+  --cwd "$PWD" \
+  --admin-preflight \
+  --target-repo-full-name <owner>/<repo> \
+  --json
+```
+
+통과하면 아래처럼 ruleset을 적용한다.
 
 ```bash
 chmod +x scripts/apply-github-rulesets.sh
@@ -230,7 +242,8 @@ scripts/apply-github-rulesets.sh <owner>/<repo>
 - `dev`: PR 경유만 허용하고 direct push를 막는다. 승인 수는 0명이다.
 - 그 외 branch: GitHub ruleset을 적용하지 않는다.
 
-이 작업에는 `gh` 인증과 target repo의 GitHub Administration write 권한이 필요하다.
+이 작업에는 `gh auth status` 통과, GitHub login `OziinG`, `EVNSolution` org membership, target repo의 GitHub Administration write 권한이 필요하다.
+새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight는 membership과 API 접근을 먼저 확인하고 실제 생성 성공은 `gh repo create` 결과로 확정한다.
 
 ### 로컬 `main` push 금지 가드
 
@@ -306,19 +319,20 @@ bootstrap packet의 `target_repo_seed_files` 항목은 위 두 파일을 target 
 
 ## 첫 대화 하드 게이트
 
-첫 질문을 던지기 전에 에이전트는 먼저 로컬 workspace 상태를 자동 감지한다.
+첫 질문을 던지기 전에 에이전트는 먼저 로컬 workspace, `gh auth status`, GitHub 계정, 원격 접근, issue/PR/ruleset 조회 가능 여부를 자동 감지한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 현재 control-plane 저장소 자체를 직접 수정하는 세션이면 아래처럼 유지보수 모드로 확인한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
-이 명령은 아래 중 하나를 돌려준다.
+`preflight_check.ready=false`이면 시작 질문으로 내려가지 않고 실패한 check를 먼저 해결한다.
+`true`이면 내부 `workspace_check.agent_action`이 아래 중 하나를 돌려준다.
 
 - `proceed-with-hard-gate`: 현재 위치에서 시작 템플릿으로 진행
 - `current-repo-maintenance`: 현재 control-plane 저장소 자체를 수정하는 세션으로 보고 여기서 계속

--- a/docs/templates/target-repo-AGENTS.md
+++ b/docs/templates/target-repo-AGENTS.md
@@ -18,6 +18,30 @@
 
 값이 아직 확정되지 않은 항목은 `pending`으로 남기고, 추측해서 채우지 않는다.
 
+## Preflight Gate
+
+새 target repo에서 팀 작업 자동화, issue/PR 동시작업 판정, ruleset 적용, CODEOWNERS/CI 보강 같은 team-work automation을 시작하기 전에는 control-plane preflight가 먼저 통과되어야 한다.
+
+control-plane workspace의 `clever-agent-project`에서 실행한다.
+
+```bash
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+```
+
+repo 생성, ruleset 적용, branch protection 변경처럼 GitHub admin 권한이 필요한 단계는 대상 repo를 지정해 admin preflight를 다시 통과한다.
+
+```bash
+python3 scripts/bootstrap_clever_work.py \
+  --cwd "$PWD" \
+  --admin-preflight \
+  --target-repo-full-name <target_repo_full_name> \
+  --json
+```
+
+preflight는 최소한 `gh auth status`, GitHub login `OziinG`, `EVNSolution` org membership, `EVNSolution/*` origin, public repo, issue/PR/ruleset 조회 권한, clean worktree, remote fetch 접근을 확인한다.
+새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight 통과 후 `gh repo create` 성공 결과를 생성 proof로 본다.
+실패하면 구현 계획, repo bootstrap, 동시작업 gate 판정으로 내려가지 않는다.
+
 ## 저장소 역할
 
 이 저장소는 구현 대상 repo다.

--- a/docs/templates/target-repo-AGENTS.md
+++ b/docs/templates/target-repo-AGENTS.md
@@ -79,6 +79,27 @@ preflight는 최소한 `gh auth status`, GitHub login `OziinG`, `EVNSolution` or
 초기 remote bootstrap 후에는 `dev`를 만들고, 이후 일반 작업은 `dev` 또는 task branch에서 진행한다.
 `dev`가 생긴 뒤에는 `main`에 직접 push하지 않는다.
 
+### PR 완료 후 branch 정리
+
+PR이 merge됐거나 source branch를 버리기로 하고 closed 처리된 뒤에는 task
+branch를 정리한다. 단, 해당 branch가 아직 open PR, 후속 issue, child branch,
+active release/hotfix에 쓰이면 삭제하지 않는다.
+
+기본 명령은 아래 순서다.
+
+```bash
+git switch dev
+git pull --ff-only origin dev
+git branch -d <source-branch>
+git push origin --delete <source-branch>
+git fetch --prune origin
+```
+
+- `main`과 `dev`는 삭제 대상이 아니다.
+- 기본은 `git branch -d <source-branch>`를 쓴다.
+- merge 없이 닫은 branch를 폐기해야 할 때만 사용자 확인 후 `git branch -D <source-branch>`를 쓴다.
+- remote branch가 GitHub에서 이미 삭제됐더라도 `git fetch --prune origin`으로 로컬 추적 branch를 정리한다.
+
 ## GitHub Ruleset 운영
 
 새 프로젝트 repo는 public으로 만든다.
@@ -173,6 +194,16 @@ chmod +x .git/hooks/pre-push
 
 `pre-commit`은 잘못된 branch 이름에서 commit 생성을 막는다.
 `pre-push`는 `main` direct push와 잘못된 branch 이름 push를 막는다.
+
+## PR 완료 후 branch 정리
+
+PR merge가 끝나고 source branch에 open PR이 더 없으면 remote/local task branch를 정리한다.
+`main`과 `dev`는 삭제 대상이 아니다.
+
+```bash
+git push origin --delete <source-branch>
+git branch -d <source-branch>
+```
 
 ## Issue 연결 규칙
 

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -506,6 +506,23 @@ def test_target_repo_ruleset_template_applies_main_and_dev_only():
     assert "새 프로젝트 repo는 public으로 만든다" in agents
 
 
+def test_docs_require_remote_task_branch_cleanup_after_pr_completion():
+    docs = [
+        REPO_ROOT / "AGENTS.md",
+        REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md",
+        REPO_ROOT / "docs/setting.md",
+        REPO_ROOT / "docs/templates/target-repo-AGENTS.md",
+    ]
+
+    for doc_path in docs:
+        text = doc_path.read_text(encoding="utf-8")
+        assert "PR 완료 후 branch 정리" in text
+        assert "git push origin --delete <source-branch>" in text
+        assert "git branch -d <source-branch>" in text
+        assert "main`과 `dev`는 삭제 대상이 아니다" in text
+        assert "open PR" in text
+
+
 def test_target_repo_pr_template_makes_review_finish_with_wiki_update():
     pr_template = (
         REPO_ROOT / "docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md"

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -553,7 +553,7 @@ def test_agent_project_agents_file_is_clone_ready_for_startup_questions():
     assert "질문 원장" in agents
     assert "known answer" in agents
     assert "needs-input" in agents
-    assert "python3 scripts/bootstrap_clever_work.py --cwd \"$PWD\" --workspace-check --json" in agents
+    assert "python3 scripts/bootstrap_clever_work.py --cwd \"$PWD\" --preflight --json" in agents
     assert "작업 종류" in agents
     assert "구조" in agents
     assert "이번 세션 목표" in agents
@@ -579,7 +579,7 @@ def test_readme_exposes_copyable_first_clone_command_box():
     assert readme.count("git clone https://github.com/EVNSolution/clever-context-monorepo.git") == 1
     assert readme.count("git clone https://github.com/EVNSolution/clever-change-control.git") == 1
     assert "cd clever-agent-project" in readme
-    assert "python3 scripts/bootstrap_clever_work.py --cwd \"$PWD\" --workspace-check --json" in readme
+    assert "python3 scripts/bootstrap_clever_work.py --cwd \"$PWD\" --preflight --json" in readme
     assert "에이전트 종류별 실행 예시" in readme
     assert "codex --yolo" in readme
     assert "claude --dangerously-skip-permissions" in readme
@@ -679,6 +679,227 @@ def test_cli_workspace_check_returns_ready_status_in_start_repo():
     assert report["startup_ready"] is True
     assert report["agent_action"] == "proceed-with-hard-gate"
     assert report["current_repo"] == "clever-agent-project"
+
+
+def test_preflight_check_passes_when_github_account_workspace_and_remotes_are_ready(
+    monkeypatch,
+):
+    module = load_module()
+    command_log: list[tuple[str, ...]] = []
+
+    def fake_which(name: str) -> str | None:
+        return f"/usr/bin/{name}" if name in {"git", "gh"} else None
+
+    def fake_workspace_check(cwd: Path, *, current_repo_maintenance: bool = False):
+        return {
+            "startup_ready": True,
+            "agent_action": "proceed-with-hard-gate",
+            "repos": {
+                "clever-agent-project": {"checkout_path": "/workspace/clever-agent-project"},
+                "clever-context-monorepo": {
+                    "checkout_path": "/workspace/clever-context-monorepo"
+                },
+                "clever-change-control": {"checkout_path": "/workspace/clever-change-control"},
+            },
+        }
+
+    def fake_run(cmd: list[str], cwd: Path | None = None):
+        command_log.append(tuple(cmd))
+        if cmd[:3] == ["gh", "api", "user"]:
+            return module.CommandResult(0, "OziinG\n", "")
+        if cmd[:3] == ["gh", "api", "user/memberships/orgs/EVNSolution"]:
+            return module.CommandResult(0, json.dumps({"state": "active", "role": "admin"}), "")
+        if cmd[:2] == ["gh", "auth"]:
+            return module.CommandResult(0, "Logged in to github.com as OziinG\n", "")
+        if cmd[:3] == ["git", "-C", "/workspace/clever-agent-project"]:
+            if cmd[3:] == ["remote", "get-url", "origin"]:
+                return module.CommandResult(
+                    0, "https://github.com/EVNSolution/clever-agent-project.git\n", ""
+                )
+            if cmd[3:] == ["status", "--short"]:
+                return module.CommandResult(0, "", "")
+            if cmd[3:] == ["fetch", "--dry-run", "origin"]:
+                return module.CommandResult(0, "", "")
+        if cmd[:3] == ["git", "-C", "/workspace/clever-context-monorepo"]:
+            if cmd[3:] == ["remote", "get-url", "origin"]:
+                return module.CommandResult(
+                    0, "https://github.com/EVNSolution/clever-context-monorepo.git\n", ""
+                )
+            if cmd[3:] == ["status", "--short"]:
+                return module.CommandResult(0, "", "")
+            if cmd[3:] == ["fetch", "--dry-run", "origin"]:
+                return module.CommandResult(0, "", "")
+        if cmd[:3] == ["git", "-C", "/workspace/clever-change-control"]:
+            if cmd[3:] == ["remote", "get-url", "origin"]:
+                return module.CommandResult(
+                    0, "https://github.com/EVNSolution/clever-change-control.git\n", ""
+                )
+            if cmd[3:] == ["status", "--short"]:
+                return module.CommandResult(0, "", "")
+            if cmd[3:] == ["fetch", "--dry-run", "origin"]:
+                return module.CommandResult(0, "", "")
+        if cmd[:3] == ["gh", "repo", "view"]:
+            return module.CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "nameWithOwner": cmd[3],
+                        "visibility": "PUBLIC",
+                        "isPrivate": False,
+                        "viewerPermission": "ADMIN",
+                    }
+                ),
+                "",
+            )
+        if cmd[:2] == ["gh", "issue"]:
+            return module.CommandResult(0, "[]\n", "")
+        if cmd[:2] == ["gh", "pr"]:
+            return module.CommandResult(0, "[]\n", "")
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/rulesets"):
+            return module.CommandResult(0, "[]\n", "")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(module.shutil, "which", fake_which)
+    monkeypatch.setattr(module, "build_workspace_check", fake_workspace_check)
+    monkeypatch.setattr(module, "run_command_result", fake_run)
+
+    report = module.build_preflight_check(
+        cwd=REPO_ROOT,
+        expected_github_login="OziinG",
+        github_owner="EVNSolution",
+    )
+
+    assert report["ready"] is True
+    assert report["mode"] == "basic"
+    assert report["github_login"] == "OziinG"
+    assert {check["name"]: check["status"] for check in report["checks"]} == {
+        "git-cli": "pass",
+        "gh-cli": "pass",
+        "gh-auth": "pass",
+        "github-account": "pass",
+        "github-org-membership": "pass",
+        "workspace": "pass",
+        "control-plane-remotes": "pass",
+        "control-plane-worktrees-clean": "pass",
+        "control-plane-remote-fetch": "pass",
+        "github-repo-access": "pass",
+        "github-issue-pr-access": "pass",
+        "ruleset-read": "pass",
+    }
+    assert ("gh", "api", "user", "--jq", ".login") in command_log
+
+
+def test_preflight_check_fails_before_startup_when_github_login_is_wrong(monkeypatch):
+    module = load_module()
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        module,
+        "build_workspace_check",
+        lambda cwd, *, current_repo_maintenance=False: {
+            "startup_ready": True,
+            "agent_action": "proceed-with-hard-gate",
+            "repos": {},
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "run_command_result",
+        lambda cmd, cwd=None: module.CommandResult(
+            0,
+            "jiinlim\n" if cmd[:3] == ["gh", "api", "user"] else "",
+            "",
+        ),
+    )
+
+    report = module.build_preflight_check(
+        cwd=REPO_ROOT,
+        expected_github_login="OziinG",
+        github_owner="EVNSolution",
+    )
+
+    assert report["ready"] is False
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["github-account"]["status"] == "fail"
+    assert "OziinG" in checks["github-account"]["message"]
+    assert "jiinlim" in checks["github-account"]["message"]
+
+
+def test_admin_preflight_requires_admin_permission_for_target_repo(monkeypatch):
+    module = load_module()
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        module,
+        "build_workspace_check",
+        lambda cwd, *, current_repo_maintenance=False: {
+            "startup_ready": True,
+            "agent_action": "proceed-with-hard-gate",
+            "repos": {},
+        },
+    )
+
+    def fake_run(cmd: list[str], cwd: Path | None = None):
+        if cmd[:2] == ["gh", "auth"]:
+            return module.CommandResult(0, "Logged in\n", "")
+        if cmd[:3] == ["gh", "api", "user"]:
+            return module.CommandResult(0, "OziinG\n", "")
+        if cmd[:3] == ["gh", "api", "user/memberships/orgs/EVNSolution"]:
+            return module.CommandResult(0, json.dumps({"state": "active", "role": "admin"}), "")
+        if cmd[:3] == ["gh", "repo", "view"]:
+            return module.CommandResult(
+                0,
+                json.dumps(
+                    {
+                        "nameWithOwner": cmd[3],
+                        "visibility": "PUBLIC",
+                        "isPrivate": False,
+                        "viewerPermission": "WRITE",
+                    }
+                ),
+                "",
+            )
+        if cmd[:2] == ["gh", "issue"] or cmd[:2] == ["gh", "pr"]:
+            return module.CommandResult(0, "[]\n", "")
+        if cmd[:2] == ["gh", "api"] and cmd[2].endswith("/rulesets"):
+            return module.CommandResult(0, "[]\n", "")
+        if cmd[:1] == ["git"]:
+            return module.CommandResult(0, "", "")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(module, "run_command_result", fake_run)
+
+    report = module.build_preflight_check(
+        cwd=REPO_ROOT,
+        expected_github_login="OziinG",
+        github_owner="EVNSolution",
+        admin=True,
+        target_repo_full_name="EVNSolution/example-target",
+    )
+
+    assert report["ready"] is False
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["target-repo-admin"]["status"] == "fail"
+    assert "ADMIN" in checks["target-repo-admin"]["message"]
+
+
+def test_docs_require_preflight_before_startup_and_admin_repo_bootstrap():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    skill = (REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    target_agents = (REPO_ROOT / "docs/templates/target-repo-AGENTS.md").read_text(
+        encoding="utf-8"
+    )
+
+    for text in (readme, agents, skill):
+        assert "--preflight" in text
+        assert "gh auth status" in text
+        assert "OziinG" in text
+        assert "--admin-preflight" in text
+    assert "Preflight Gate" in target_agents
+    assert "team-work automation" in target_agents
 
 
 def test_cli_workspace_check_allows_current_repo_maintenance_when_flagged():


### PR DESCRIPTION
# CLEVER PR review completion

- target repo: `clever-agent-project`
- target service: control-plane startup
- target branch: `main`
- source branch: `feature/preflight-start-gate`
- project-start issue: none
- change-control issue: none
- target repo issue: none

## 변경 내용
- `bootstrap_clever_work.py`에 `--preflight`와 `--admin-preflight` 추가
- 시작 전 검증에 `git`, `gh`, `gh auth status`, GitHub login `OziinG`, `EVNSolution` org membership, 3레포 workspace, origin, clean worktree, remote fetch, repo visibility, issue/PR/ruleset read access 추가
- admin preflight에서 target repo public/admin 권한 확인 추가
- repo 생성 권한은 destructive create 없이 완전 증명할 수 없다는 한계를 문서화하고, `gh repo create` 성공을 생성 proof로 보도록 정리
- PR 완료 후 source branch cleanup 규칙 추가

## 검증
- `uvx pytest clever-agent-project/tests -q` -> 52 passed, 2 skipped
- `python3 -m py_compile clever-agent-project/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py clever-agent-project/scripts/bootstrap_clever_work.py`
- `git diff --check`
- 실제 `--preflight` smoke: 계정/권한/원격 조회는 통과, 작업 중 dirty state 때문에 clean-worktree check만 실패함
- 실제 `--admin-preflight --target-repo-full-name EVNSolution/clever-agent-project` smoke: target-repo-admin 통과, 작업 중 dirty state 때문에 clean-worktree check만 실패함

## Concurrent Work Gate

- parallel work decision: `allowed-with-non-overlap`
- target repo issue: none
- clever-change-control issue: none
- open PR checked: no blocking open PR in this repo
- conflict candidates: local `docs/templates/startup-branch-state-template.md` OIDC typo correction is outside this PR scope
- user-forced-proceed reason: not used

## PR 검토 에이전트 종료 조건

- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- PR 정보를 wiki에 올리지 않는다.
- wiki에는 필요한 서비스 책임, public contract, deploy/runtime 기준, 운영 caveat, 빠른 탐색 요약만 반영한다.

## Context/wiki completion

- context docs checked:
  - `clever-context-monorepo/docs/root/agent-runtime-governance.md`
  - `clever-context-monorepo/AGENTS.md`
  - `clever-context-monorepo/README.md`
- wiki/service context update result: `updated`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: EVNSolution/clever-context-monorepo#9
- not-needed reason: root runtime governance was updated directly; wiki/service page not needed

## Linked issue close evidence

- linked issue close evidence: preflight gate added and context/change-control sync PRs opened
- 이슈 종료는 PR 검토 완료 결과를 근거로 처리한다.
- 이슈 종료 코멘트에는 wiki/service context 반영 결과 또는 불필요 사유를 이 PR에서 복사해 남긴다.

## PR 기준

- `dev` PR과 `main` PR은 검토 에이전트 종료 조건을 채운다.
- `main` PR은 deploy merge 단위로 보고 wiki/service context 업데이트 여부를 다시 확인한다.
- `dev` PR은 integration merge 단위로 보고 issue close 전에 wiki/service context 업데이트 여부를 확인한다.
