### PR TITLE
docs: add PR branch cleanup template

### DIFF
--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -61,16 +61,6 @@ Preflight also checks active `EVNSolution` org membership. Repository creation
 permission cannot be proven without the actual `gh repo create` write attempt,
 so treat that command's success as the creation proof after preflight passes.
 
-## PR 완료 후 branch 정리
-
-After a PR is merged, delete the source task branch only when there is no other
-open PR using that branch. `main`과 `dev`는 삭제 대상이 아니다.
-
-```bash
-git push origin --delete <source-branch>
-git branch -d <source-branch>
-```
-
 Before planning, implementation, `project-start` creation, or repo bootstrap, the agent must first normalize the session into the same opening structure.
 
 Use this exact first-response template:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,16 +69,6 @@ Repository creation permission cannot be proven without the actual write attempt
 Treat org membership and token/API access as the pre-create gate, then treat
 `gh repo create` success as the creation proof.
 
-## PR 완료 후 branch 정리
-
-PR merge가 끝나고 source branch에 open PR이 더 없으면 remote/local task branch를 정리한다.
-`main`과 `dev`는 삭제 대상이 아니다.
-
-```bash
-git push origin --delete <source-branch>
-git branch -d <source-branch>
-```
-
 ## Clone-Ready Startup Contract
 
 This section exists for a fresh clone of `clever-agent-project`.

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -266,16 +266,6 @@ scripts/apply-github-rulesets.sh <owner>/<repo>
 이 작업에는 `gh auth status` 통과, GitHub login `OziinG`, `EVNSolution` org membership, target repo의 GitHub Administration write 권한이 필요하다.
 새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight는 membership과 API 접근을 먼저 확인하고 실제 생성 성공은 `gh repo create` 결과로 확정한다.
 
-### PR 완료 후 branch 정리
-
-PR merge가 끝나고 source branch에 open PR이 더 없으면 remote/local task branch를 정리한다.
-`main`과 `dev`는 삭제 대상이 아니다.
-
-```bash
-git push origin --delete <source-branch>
-git branch -d <source-branch>
-```
-
 ### 로컬 `main` push 금지 가드
 
 `dev`를 만든 뒤에는 target repo 로컬에서 `main` direct push를 막는 것을 권장한다.

--- a/docs/templates/target-repo-AGENTS.md
+++ b/docs/templates/target-repo-AGENTS.md
@@ -195,16 +195,6 @@ chmod +x .git/hooks/pre-push
 `pre-commit`은 잘못된 branch 이름에서 commit 생성을 막는다.
 `pre-push`는 `main` direct push와 잘못된 branch 이름 push를 막는다.
 
-## PR 완료 후 branch 정리
-
-PR merge가 끝나고 source branch에 open PR이 더 없으면 remote/local task branch를 정리한다.
-`main`과 `dev`는 삭제 대상이 아니다.
-
-```bash
-git push origin --delete <source-branch>
-git branch -d <source-branch>
-```
-
 ## Issue 연결 규칙
 
 작업을 시작하기 전에 아래 연결을 확인한다.

--- a/docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md
+++ b/docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md
@@ -49,6 +49,20 @@
 - 이슈 종료는 PR 검토 완료 결과를 근거로 처리한다.
 - 이슈 종료 코멘트에는 wiki/service context 반영 결과 또는 불필요 사유를 이 PR에서 복사해 남긴다.
 
+## PR 완료 후 branch 정리
+
+- PR merge 후 source branch에 open PR, 후속 issue, child branch, active release/hotfix가 없으면 정리한다.
+- `main`과 `dev`는 삭제 대상이 아니다.
+- cleanup commands:
+
+```bash
+git switch dev
+git pull --ff-only origin dev
+git branch -d <source-branch>
+git push origin --delete <source-branch>
+git fetch --prune origin
+```
+
 ## PR 기준
 
 - `dev` PR과 `main` PR은 검토 에이전트 종료 조건을 채운다.

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -512,11 +512,13 @@ def test_docs_require_remote_task_branch_cleanup_after_pr_completion():
         REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md",
         REPO_ROOT / "docs/setting.md",
         REPO_ROOT / "docs/templates/target-repo-AGENTS.md",
+        REPO_ROOT / "docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md",
     ]
 
     for doc_path in docs:
         text = doc_path.read_text(encoding="utf-8")
         assert "PR 완료 후 branch 정리" in text
+        assert text.count("PR 완료 후 branch 정리") == 1
         assert "git push origin --delete <source-branch>" in text
         assert "git branch -d <source-branch>" in text
         assert "main`과 `dev`는 삭제 대상이 아니다" in text
@@ -546,6 +548,10 @@ def test_target_repo_pr_template_makes_review_finish_with_wiki_update():
     assert "clever-context-monorepo update" in pr_template
     assert "linked issue close evidence" in pr_template
     assert "이슈 종료는 PR 검토 완료 결과를 근거로 처리한다" in pr_template
+    assert "PR 완료 후 branch 정리" in pr_template
+    assert "git push origin --delete <source-branch>" in pr_template
+    assert "git branch -d <source-branch>" in pr_template
+    assert "main`과 `dev`는 삭제 대상이 아니다" in pr_template
 
     assert "PR 검토 에이전트 종료 조건" in agents
     assert "wiki/service context 업데이트로 마친다" in agents


### PR DESCRIPTION
# CLEVER PR review completion

- target repo: `clever-agent-project`
- target service: control-plane startup
- target branch: `main`
- source branch: `docs/pr-branch-cleanup-template`
- project-start issue: none
- change-control issue: none
- target repo issue: none

## 변경 내용
- target repo PR template에 PR 완료 후 branch 정리 섹션 추가
- branch cleanup 문구가 문서별 1회만 나오도록 중복 정리
- cleanup 테스트가 PR template까지 검증하도록 보강

## 검증
- `uvx pytest clever-agent-project/tests -q` -> 52 passed, 2 skipped
- `git diff --check`

## Concurrent Work Gate

- parallel work decision: `allowed-with-non-overlap`
- target repo issue: none
- clever-change-control issue: none
- open PR checked: no blocking open PR after #8 merge
- conflict candidates: local `docs/templates/startup-branch-state-template.md` OIDC typo correction is outside this PR scope
- user-forced-proceed reason: not used

## PR 검토 에이전트 종료 조건

- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- PR 정보를 wiki에 올리지 않는다.

## Context/wiki completion

- context docs checked:
  - `clever-context-monorepo/docs/root/agent-runtime-governance.md`
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: not-needed
- not-needed reason: this only updates target repo PR template cleanup instructions

## Linked issue close evidence

- linked issue close evidence: branch cleanup template and tests updated
- 이슈 종료는 PR 검토 완료 결과를 근거로 처리한다.

## PR 기준

- `main` PR review completion fields filled.
