### PR TITLE
[test] Validate agent startup preflight gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,7 @@ If the task is template-specific, also read:
 
 Do not jump straight into implementation.
 
-If the automatic workspace check returns `stop-and-fix-workspace`, do not continue as if the environment were complete.
+If the automatic preflight report returns `workspace_check.agent_action=stop-and-fix-workspace`, do not continue as if the environment were complete.
 
 For a new session, begin by collecting the startup branch first.
 

--- a/docs/templates/target-repo-AGENTS.md
+++ b/docs/templates/target-repo-AGENTS.md
@@ -40,7 +40,8 @@ python3 scripts/bootstrap_clever_work.py \
 
 preflight는 최소한 `gh auth status`, GitHub login `OziinG`, `EVNSolution` org membership, `EVNSolution/*` origin, public repo, issue/PR/ruleset 조회 권한, clean worktree, remote fetch 접근을 확인한다.
 새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight 통과 후 `gh repo create` 성공 결과를 생성 proof로 본다.
-실패하면 구현 계획, repo bootstrap, 동시작업 gate 판정으로 내려가지 않는다.
+출력의 `preflight_check.ready=true`를 확인한 뒤에만 구현 계획, repo bootstrap, 동시작업 gate 판정으로 내려간다.
+실패하면 해당 단계로 내려가지 않는다.
 
 ## 저장소 역할
 

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -926,6 +926,21 @@ def test_docs_require_preflight_before_startup_and_admin_repo_bootstrap():
     assert "team-work automation" in target_agents
 
 
+def test_agent_files_startup_behavior_uses_preflight_gate():
+    agent_files = [
+        REPO_ROOT / "AGENTS.md",
+        REPO_ROOT.parent / "clever-context-monorepo/AGENTS.md",
+        REPO_ROOT.parent / "clever-change-control/AGENTS.md",
+        REPO_ROOT / "docs/templates/target-repo-AGENTS.md",
+    ]
+
+    for doc_path in agent_files:
+        text = doc_path.read_text(encoding="utf-8")
+        assert "Run the workspace check" not in text
+        assert "automatic workspace check" not in text
+        assert "preflight_check.ready=true" in text
+
+
 def test_cli_workspace_check_allows_current_repo_maintenance_when_flagged():
     change_repo = REPO_ROOT.parent / "clever-change-control"
 


### PR DESCRIPTION
## Summary
- align AGENTS startup wording around preflight output
- make the target repo AGENTS template require `preflight_check.ready=true` before implementation/bootstrap gates
- add a regression test covering the control-plane AGENTS files

## Validation
- `uvx pytest clever-agent-project/tests -q`
- `git diff --check` across the three control-plane repos