### PR TITLE
[docs] Align startup guides with preflight

### DIFF
--- a/docs/guides/session-start-smoke-test.md
+++ b/docs/guides/session-start-smoke-test.md
@@ -51,15 +51,16 @@
 운영 환경에서는 첫 질문 전에 아래 자동 감지 명령을 먼저 돌린다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
-이 문서의 시나리오는 그 결과가 `proceed-with-hard-gate`일 때 시작 하드 게이트가 제대로 적용되는지 보는 테스트다.
+이 문서의 시나리오는 그 결과가 `preflight_check.ready=true`이고
+`workspace_check.agent_action=proceed-with-hard-gate`일 때 시작 하드 게이트가 제대로 적용되는지 보는 테스트다.
 
 현재 control-plane 저장소 자체를 직접 수정하는 세션은 아래처럼 유지보수 모드로 따로 확인한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
 ## 합격 기준
@@ -205,7 +206,7 @@ This workspace is incomplete, so startup interpretation and traceability are deg
 
 에이전트는 아래처럼 움직여야 한다.
 
-1. 먼저 `workspace-check`를 돌린다.
+1. 먼저 `preflight`를 돌린다.
 2. 로컬 3레포 workspace가 완전하다고 확인한다.
 3. 하지만 현재 위치가 generic startup surface가 아니라는 점을 인식한다.
 4. `switch-to-clever-agent-project`로 분기한다.
@@ -231,7 +232,7 @@ Switch there before applying the first-response hard gate.
 
 에이전트는 아래처럼 움직여야 한다.
 
-1. 먼저 `workspace-check`를 돌린다.
+1. 먼저 `preflight`를 돌린다.
 2. 로컬 3레포 workspace가 완전하다고 확인한다.
 3. 현재 control-plane 저장소 자체를 수정하는 세션이라고 본다.
 4. `current-repo-maintenance`로 분기한다.
@@ -278,4 +279,4 @@ Stay in the current repository and treat it as the target for this session.
 
 1. `project-start` payload 초안 품질
 2. target repo handoff 규칙
-3. workspace check 자동화
+3. preflight 자동화

--- a/docs/guides/three-repo-startup-alignment.md
+++ b/docs/guides/three-repo-startup-alignment.md
@@ -32,7 +32,7 @@
 
 아래는 현재 모델에 맞춰 이미 정리된 영역이다.
 
-- `workspace-check` 자동 감지 추가
+- `preflight` 자동 감지 추가
 - `agent_action` 기준 분기
   - `proceed-with-hard-gate`
   - `current-repo-maintenance`
@@ -82,7 +82,7 @@
 `clever-context-monorepo/README.md`와 `clever-change-control/README.md`는 각 레포의 역할은 설명하지만, 아직 아래를 전면에 두지는 않는다.
 
 - generic startup vs repo-local maintenance 분기
-- `workspace-check` 우선 실행
+- `preflight` 우선 실행
 - `switch-to-clever-agent-project`와 `stop-and-fix-workspace`의 차이
 
 현재는 이 역할을 각 레포의 `AGENTS.md`가 대신한다.
@@ -100,7 +100,7 @@
 
 ### 3. 시작 모델의 end-to-end 검증은 아직 수동 시나리오 중심이다
 
-현재 자동 검증은 `bootstrap_clever_work.py --workspace-check`와 helper 테스트 수준이다.
+현재 자동 검증은 `bootstrap_clever_work.py --preflight`와 helper 테스트 수준이다.
 
 아직 없는 것은 아래다.
 
@@ -117,12 +117,12 @@
 - 어떤 요청을 repo-local maintenance로 볼지
 - ambiguous case에서 에이전트가 어떤 추가 질문을 해야 하는지
 
-### 5. sibling repo에서의 `workspace-check` 경로는 sibling layout을 전제로 한다
+### 5. sibling repo에서의 `preflight` 경로는 sibling layout을 전제로 한다
 
 현재 경량 `AGENTS.md`는 아래 명령을 사용한다.
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 이건 3레포가 같은 workspace root 아래 sibling으로 있는 구조를 전제로 한다.
@@ -139,7 +139,7 @@ python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --
 
 - generic startup이면 `clever-agent-project`로 이동
 - repo-local maintenance면 현재 레포 유지
-- `workspace-check` 우선 실행
+- `preflight` 우선 실행
 
 ### 2. repo-local maintenance 예시 문서
 

--- a/docs/templates/startup-branch-state-template.md
+++ b/docs/templates/startup-branch-state-template.md
@@ -110,7 +110,7 @@ repo와 service가 둘 다 확정되지 않았으면 빈 값으로 둔다.
 
 ### workspace
 
-- 시작 전에 `workspace-check` 결과를 기록한다.
+- 시작 전에 `preflight` 결과와 `workspace_check.agent_action`을 기록한다.
 - generic startup이면 `workspace_check_mode: generic_startup`
 - 현재 저장소 직접 수정이면 `workspace_check_mode: current_repo_maintenance`
 

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -941,6 +941,21 @@ def test_agent_files_startup_behavior_uses_preflight_gate():
         assert "preflight_check.ready=true" in text
 
 
+def test_startup_guides_use_preflight_command_not_legacy_workspace_cli():
+    startup_docs = [
+        REPO_ROOT / "docs/guides/session-start-smoke-test.md",
+        REPO_ROOT / "docs/guides/three-repo-startup-alignment.md",
+        REPO_ROOT / "docs/templates/startup-branch-state-template.md",
+    ]
+
+    for doc_path in startup_docs:
+        text = doc_path.read_text(encoding="utf-8")
+        assert "--workspace-check" not in text
+        assert "`workspace-check`" not in text
+        assert "workspace check 자동화" not in text
+        assert "preflight" in text
+
+
 def test_cli_workspace_check_allows_current_repo_maintenance_when_flagged():
     change_repo = REPO_ROOT.parent / "clever-change-control"
 


### PR DESCRIPTION
## Summary
- replace legacy startup guide `--workspace-check` commands with `--preflight`
- make startup branch state record preflight output plus `workspace_check.agent_action`
- add a regression test to keep startup docs on the preflight command path

## Validation
- `uvx pytest tests -q`
- `git diff --check`