### PR TITLE
docs: add PR scope grouping gate

### DIFF
--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -350,6 +350,25 @@ Record exactly one decision:
   body, then continue until a real git conflict, test failure, or merge failure
   must be resolved.
 
+## PR Scope Grouping Gate
+
+Before opening a PR, decide whether the changes should stay together or be
+split.
+
+Keep one PR when the changes share the same document/operating-rule cleanup and
+the same validation command covers them. This includes small sync work across
+`AGENTS.md`, PR templates, startup state templates, project brief templates,
+design source policy, and merge title template sync when they all express the
+same operating rule.
+
+Split PRs when the work crosses a different app/service/contract surface, has a
+different test scope or likely failure point, has a merge order dependency, or
+would need a different rollback unit.
+
+OpenAPI schema changes, Admin Web smoke screen work, Rider App smoke screen
+work, and Spring service mock endpoint work are examples that usually deserve
+separate PRs.
+
 ## Standard Packet
 
 Before the helper script, every run should normalize the startup branch state into this shape:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,18 @@
 
 -
 
+## PR Scope Grouping Gate
+
+- grouping decision: `single-pr` / `split-required`
+- same document/operating-rule cleanup:
+- same validation command:
+- different app/service/contract surface:
+- merge order dependency:
+- rollback unit:
+
+같은 issue 안의 같은 운영 문서/절차 정리이고 같은 검증으로 충분하면 `single-pr`로 둔다.
+앱, 서비스, 계약 표면, merge 순서, 롤백 단위가 다르면 `split-required`로 둔다.
+
 ## 테스트 여부
 
 -

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -403,6 +403,36 @@ The decision and evidence must be written to both the target repo issue and the
 clever-change-control issue. The PR body must repeat the final parallel work
 decision.
 
+## PR Scope Grouping Gate
+
+Before opening a PR, decide whether the current changes belong in one PR or
+must be split.
+
+Prefer one PR when the work is the same document/operating-rule cleanup and the
+same validation command is enough to review it. Do not split small operational
+documentation cleanup only because it touches several policy or template files;
+that creates repeated issue linkage and context-completion records without a
+clearer review unit.
+
+Keep one PR when:
+
+- the changes are under the same issue and the same document/operating-rule
+  cleanup axis
+- the same validation command covers the full change
+- the touched files are sync targets for the same policy, such as `AGENTS.md`,
+  PR templates, startup state templates, project brief templates, design source
+  policy, or merge title template sync
+
+Split into separate PRs when:
+
+- the work touches a different app/service/contract surface
+- the test scope and likely failure point are different
+- there is a merge order dependency between parts
+- a failure would require a different rollback unit
+
+Examples that should usually be split: OpenAPI schema changes, Admin Web smoke
+screen work, Rider App smoke screen work, and Spring service mock endpoint work.
+
 During and after the work, update the `clever-change-control` issue with:
 
 - current session phase: documentation, implementation, verification, or release

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -216,6 +216,27 @@ private repo ruleset enforce가 필요하면 GitHub Team, GitHub Pro, 또는 Git
 
 즉 `dev`는 통합 작업선이고, task branch는 역할별 작업선이다.
 
+### PR Scope Grouping Gate
+
+PR은 파일 수가 아니라 변경 축과 검증 단위로 나눈다.
+
+같은 issue 안에서 same document/operating-rule cleanup 축이고 same validation command로
+충분하면 한 PR로 묶는다. `AGENTS.md`, PR template, startup state
+template, project brief template, design source policy, merge title template
+sync처럼 같은 운영 규칙을 맞추는 작은 문서 정리는 여러 PR로 나누지 않는다.
+나누면 리뷰 단위보다 추적 단위가 커지고, issue 연결과 context completion
+기록만 반복된다.
+
+분리 PR은 아래 경우에만 기본값으로 둔다.
+
+- different app/service/contract surface를 건드린다.
+- 테스트 범위와 실패 지점이 다르다.
+- merge order dependency가 있다.
+- 실패 시 rollback unit이 다르다.
+
+예: OpenAPI schema 변경, Admin Web smoke 화면 구현, Rider App smoke 화면 구현,
+Spring service mock endpoint 구현은 검증과 실패 지점이 달라 보통 분리한다.
+
 ### PR 완료 후 branch 정리
 
 PR이 merge됐거나 source branch를 버리기로 하고 closed 처리된 뒤에는 task

--- a/docs/templates/target-repo-AGENTS.md
+++ b/docs/templates/target-repo-AGENTS.md
@@ -242,6 +242,32 @@ clever-change-control issue를 동시에 확인한다.
 `user-forced-proceed`는 에이전트의 안전 판단이 아니다.
 사용자 강제 진행 기록이며, 실제 git conflict, 테스트 실패, merge 실패가 발생하면 그 시점에 해결하거나 중단 보고한다.
 
+## PR Scope Grouping Gate
+
+PR을 열기 전에 현재 변경을 한 PR로 묶을지, 분리 PR로 나눌지 판단한다.
+
+같은 issue 안에서 same document/operating-rule cleanup 축이고 same validation command로
+충분하면 한 PR로 묶는다. 여러 정책 문서나 템플릿 파일을 같이
+건드렸다는 이유만으로 작은 운영 문서 정리를 쪼개지 않는다.
+
+한 PR로 묶는 기준:
+
+- 같은 issue와 같은 document/operating-rule cleanup 축이다.
+- 같은 validation command가 전체 변경을 검증한다.
+- `AGENTS.md`, PR template, startup state template, project brief template,
+  design source policy, merge title template sync처럼 같은 운영 규칙을 맞추는
+  sync 대상이다.
+
+분리 PR로 나누는 기준:
+
+- different app/service/contract surface를 건드린다.
+- 테스트 범위와 실패 지점이 다르다.
+- merge order dependency가 있다.
+- 실패 시 rollback unit이 다르다.
+
+예: OpenAPI schema 변경, Admin Web smoke 화면, Rider App smoke 화면, Spring
+service mock endpoint 구현은 보통 분리 PR로 다룬다.
+
 ## 구현 규칙
 
 - 기존 코드 스타일과 도구를 우선한다.

--- a/docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md
+++ b/docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,18 @@
 
 -
 
+## PR Scope Grouping Gate
+
+- grouping decision: `single-pr` / `split-required`
+- same document/operating-rule cleanup:
+- same validation command:
+- different app/service/contract surface:
+- merge order dependency:
+- rollback unit:
+
+같은 issue 안의 같은 운영 문서/절차 정리이고 같은 검증으로 충분하면 `single-pr`로 둔다.
+앱, 서비스, 계약 표면, merge 순서, 롤백 단위가 다르면 `split-required`로 둔다.
+
 ## 검증
 
 -

--- a/tests/test_concurrent_work_gate.py
+++ b/tests/test_concurrent_work_gate.py
@@ -53,3 +53,27 @@ def test_pr_templates_require_parallel_work_decision():
         assert "parallel work decision" in text
         assert "conflict candidates" in text
         assert "user-forced-proceed" in text
+
+
+def test_pr_scope_grouping_guidance_is_documented_and_in_templates():
+    policy_surfaces = [
+        read(REPO_ROOT / "AGENTS.md"),
+        read(REPO_ROOT / "docs/setting.md"),
+        read(REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md"),
+        read(REPO_ROOT / "docs/templates/target-repo-AGENTS.md"),
+        read(CONTEXT_ROOT / "docs/root/pipeline-governance.md"),
+    ]
+    pr_templates = [
+        read(REPO_ROOT / ".github/PULL_REQUEST_TEMPLATE.md"),
+        read(REPO_ROOT / "docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md"),
+        read(CONTEXT_ROOT / ".github/PULL_REQUEST_TEMPLATE.md"),
+        read(CHANGE_CONTROL_ROOT / ".github/PULL_REQUEST_TEMPLATE.md"),
+    ]
+
+    for text in policy_surfaces + pr_templates:
+        assert "PR Scope Grouping Gate" in text
+        assert "same document/operating-rule cleanup" in text
+        assert "same validation command" in text
+        assert "different app/service/contract surface" in text
+        assert "merge order dependency" in text
+        assert "rollback unit" in text


### PR DESCRIPTION
## change id

- not assigned

## 관련 issue

- not assigned

## 대상 repo/service

- `EVNSolution/clever-agent-project`
- service: control-plane docs/templates

## 변경 내용

- Add `PR Scope Grouping Gate` to agent operating rules, settings, bootstrap skill, and target repo seed docs.
- Add the same gate to the control-plane and target repo PR templates.
- Add regression coverage so the grouping policy stays synchronized across policy surfaces and templates.

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: yes, PR grouping policy and templates are one operating-rule sync.
- same validation command: yes, workspace doc/template sync is covered by the same pytest and diff-check verification.
- different app/service/contract surface: no product app, service, API, or contract surface changes.
- merge order dependency: none.
- rollback unit: repo-local docs/templates only.

## 테스트 여부

- `python3 -m pytest -q` in `clever-agent-project`: 55 passed, 2 skipped
- `git diff --check` in `clever-agent-project`: passed
- `git diff --check` in `clever-context-monorepo`: passed
- `git diff --check` in `clever-change-control`: passed

## 검수 포인트

- Same issue + same document/operating-rule cleanup now defaults to one PR.
- Different app/service/contract surface, merge order dependency, or different rollback unit now defaults to split PRs.
- PR templates require authors to record `single-pr` or `split-required`.

## rollout/rollback 영향

- No runtime rollout impact.
- Rollback is reverting this docs/templates commit.

## Concurrent Work Gate

- parallel work decision: `done`
- target repo issue: not assigned
- clever-change-control issue: not assigned
- open PR checked: none open at creation time
- conflict candidates: none
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `clever-context-monorepo/docs/root/pipeline-governance.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: companion branch `docs/pr-scope-grouping-gate`
- linked issue close evidence: not assigned
