### PR TITLE
tests: align context expectations with pointer-only docs

### DIFF
--- a/tests/test_concurrent_work_gate.py
+++ b/tests/test_concurrent_work_gate.py
@@ -56,13 +56,15 @@ def test_pr_templates_require_parallel_work_decision():
 
 
 def test_pr_scope_grouping_guidance_is_documented_and_in_templates():
-    policy_surfaces = [
+    shared_policy_surfaces = [
         read(REPO_ROOT / "AGENTS.md"),
         read(REPO_ROOT / "docs/setting.md"),
         read(REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md"),
         read(REPO_ROOT / "docs/templates/target-repo-AGENTS.md"),
-        read(CONTEXT_ROOT / "docs/root/pipeline-governance.md"),
     ]
+    context_pipeline_governance = read(
+        CONTEXT_ROOT / "docs/root/pipeline-governance.md"
+    )
     pr_templates = [
         read(REPO_ROOT / ".github/PULL_REQUEST_TEMPLATE.md"),
         read(REPO_ROOT / "docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md"),
@@ -70,10 +72,17 @@ def test_pr_scope_grouping_guidance_is_documented_and_in_templates():
         read(CHANGE_CONTROL_ROOT / ".github/PULL_REQUEST_TEMPLATE.md"),
     ]
 
-    for text in policy_surfaces + pr_templates:
+    for text in shared_policy_surfaces + pr_templates:
         assert "PR Scope Grouping Gate" in text
         assert "same document/operating-rule cleanup" in text
         assert "same validation command" in text
         assert "different app/service/contract surface" in text
         assert "merge order dependency" in text
         assert "rollback unit" in text
+
+    assert "PR Scope Grouping Gate" in context_pipeline_governance
+    assert "same document/operating-rule cleanup" in context_pipeline_governance
+    assert "same validation command" in context_pipeline_governance
+    assert "different app/runtime-slice/contract surface" in context_pipeline_governance
+    assert "merge order dependency" in context_pipeline_governance
+    assert "rollback unit" in context_pipeline_governance

--- a/tests/test_issue_resolution_context_wiki_prompt.py
+++ b/tests/test_issue_resolution_context_wiki_prompt.py
@@ -32,12 +32,19 @@ class IssueResolutionContextWikiPromptTest(unittest.TestCase):
             REPO_ROOT.parent
             / "clever-context-monorepo/docs/root/doc-governance.md"
         ).read_text(encoding="utf-8")
-        self.assertIn("이슈 해결 시 context 정리 기준", context_doc)
-        self.assertIn("docs/services/<service>/index.md", context_doc)
-        self.assertIn("docs/wiki", context_doc)
-        self.assertIn("dev/main PR review completion 기준", context_doc)
-        self.assertIn("검토 에이전트 작업은 wiki/service context 업데이트로 마친다", context_doc)
-        self.assertIn("PR 정보를 wiki에 올리지 않는다", context_doc)
+        self.assertIn("PR 완료 시 context 판단", context_doc)
+        self.assertIn("clever-context-monorepo update: <commit-or-PR>", context_doc)
+        self.assertIn("`not-needed`", context_doc)
+        self.assertIn("PR 정보와 운영 증거를 wiki에 올리지 않는다", context_doc)
+        self.assertIn("외부 정본의 사실을 이 repo가 다시 설명하면 실패다", context_doc)
+        self.assertIn("docs/services/<slice>/index.md", context_doc)
+
+        self.assertNotIn("이슈 해결 시 context 정리 기준", context_doc)
+        self.assertNotIn("dev/main PR review completion 기준", context_doc)
+        self.assertNotIn(
+            "검토 에이전트 작업은 wiki/service context 업데이트로 마친다",
+            context_doc,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## change id

- n/a — control-plane test maintenance

## 관련 issue

- Follow-up from local pytest failure after `clever-context-monorepo` was reduced to pointer-only authority docs.

## 대상 repo/service

- `EVNSolution/clever-agent-project`
- Python cross-repo tests

## 변경 내용

- `tests/test_concurrent_work_gate.py`에서 target templates/shared policy surfaces와 `clever-context-monorepo/docs/root/pipeline-governance.md` 기대 문구를 분리했습니다.
- context root docs는 clean vocabulary인 `different app/runtime-slice/contract surface`를 허용하도록 바꿨습니다.
- `tests/test_issue_resolution_context_wiki_prompt.py`가 context doc에 상세 prompt 문구를 요구하지 않고, pointer-level governance 문구와 `not-needed` 기준을 검증하도록 바꿨습니다.
- 반대로 verbose issue-resolution prompt heading / dev-main review phrase가 context doc에 다시 들어가지 않도록 negative assertions를 추가했습니다.

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: 같은 pytest expectation cleanup 축입니다.
- same validation command: `python3 -m pytest -q`와 `git diff --check`로 전체 변경 검증 가능.
- different app/service/contract surface: 없음. Python test expectation만 변경.
- merge order dependency: 없음
- rollback unit: 이 PR 전체

## 테스트 여부

- `python3 -m pytest -q tests/test_concurrent_work_gate.py::test_pr_scope_grouping_guidance_is_documented_and_in_templates tests/test_issue_resolution_context_wiki_prompt.py::IssueResolutionContextWikiPromptTest::test_issue_resolution_context_wiki_prompt_is_available_and_linked`
  - 2 passed
- `python3 -m pytest -q`
  - 55 passed, 2 skipped
- `git diff --check`
  - whitespace error 없음
- `python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json`
  - `ready=True`, failed checks 없음

## 검수 포인트

- `clever-context-monorepo` 문서는 수정하지 않았습니다.
- 테스트가 context repo를 target-repo prompt/detail 저장소로 만들지 않도록 기대값을 낮춘 것이 아니라, pointer-only governance 기준으로 바꿨습니다.
- `clever-agent-project`의 prompt/template 상세 검증은 유지됩니다.

## rollout/rollback 영향

- 런타임 영향 없음. 테스트 코드만 변경.
- rollback은 이 PR revert로 가능.

## Concurrent Work Gate

- parallel work decision: `allowed-with-non-overlap`
- target repo issue: n/a
- clever-change-control issue: n/a
- open PR checked: open PR conflict 없음
- conflict candidates: ThunderCrew contracts PR과 별도 repo/별도 surface
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `clever-context-monorepo/docs/root/doc-governance.md`, `clever-context-monorepo/docs/root/pipeline-governance.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: not-needed
- linked issue close evidence: n/a
