### PR TITLE
[일반 개발][변경] 사용자별 GitHub 계정 preflight 적용

### DIFF
--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -33,17 +33,19 @@ Do not put the project planning draft into `AGENTS.md`.
 
 ## First-Response Hard Gate
 
-Before showing the first-response template, automatically inspect the local workspace,
-`gh auth status`, GitHub account, remotes, repo visibility, and issue/PR/ruleset read access:
+Before showing the first-response template, ask the user for their GitHub login or profile URL, then automatically inspect the local workspace,
+`gh auth status`, GitHub login, remotes, repo visibility, and issue/PR/ruleset read access:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 If the session is explicitly about editing the current control-plane repo itself, run:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
 Interpret the result like this:
@@ -55,8 +57,8 @@ Interpret the result like this:
 - `workspace_check.agent_action=switch-to-clever-agent-project`: move startup to `clever-agent-project` first
 - `workspace_check.agent_action=stop-and-fix-workspace`: stop and clearly state that the local three-repository workspace is incomplete
 
-The expected GitHub login defaults to `OziinG`.
-Use `CLEVER_EXPECTED_GITHUB_LOGIN` or `--expected-github-login` only when the user explicitly authorizes another account.
+There is no shared default GitHub login.
+On first startup, ask the user for their GitHub login or profile URL, then pass it with `CLEVER_EXPECTED_GITHUB_LOGIN` or `--expected-github-login`.
 Preflight also checks active `EVNSolution` org membership. Repository creation
 permission cannot be proven without the actual `gh repo create` write attempt,
 so treat that command's success as the creation proof after preflight passes.
@@ -314,7 +316,7 @@ Once the user approves:
    - initial remote bootstrap commit may land on `main`
    - immediately after that, create and push `dev`
    - before applying rulesets or repository protection settings, run:
-     `python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --admin-preflight --target-repo-full-name <owner>/<repo> --json`
+     `CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --admin-preflight --target-repo-full-name <owner>/<repo> --json`
    - after `dev` exists, run `scripts/apply-github-rulesets.sh <owner>/<repo>` when GitHub Administration write permission is available
    - GitHub rulesets should target only `main` and `dev`: both require PR-only updates with `required_approving_review_count=0`, and other branches stay unrestricted by ruleset
    - after `dev` exists, block direct local pushes to `main`

--- a/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
+++ b/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
@@ -45,7 +45,11 @@ ALLOWED_UI_IMPACTS = {
     "없음",
 }
 DEFAULT_GITHUB_OWNER = "EVNSolution"
-DEFAULT_EXPECTED_GITHUB_LOGIN = "OziinG"
+DEFAULT_EXPECTED_GITHUB_LOGIN: str | None = None
+GITHUB_LOGIN_REQUEST_MESSAGE = (
+    "Ask the user for their GitHub login or profile URL, then set "
+    "CLEVER_EXPECTED_GITHUB_LOGIN or pass --expected-github-login."
+)
 
 CONTEXT_DOCS = [
     "README.md",
@@ -405,6 +409,42 @@ def normalize_repo_full_name(repo: str | None, *, github_owner: str) -> str | No
     return repo if "/" in repo else f"{github_owner}/{repo}"
 
 
+def normalize_github_login_identifier(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    candidate = value.strip()
+    if not candidate:
+        return None
+
+    candidate = re.split(r"[?#]", candidate, maxsplit=1)[0].strip().rstrip("/")
+    if candidate.startswith("@"):
+        candidate = candidate[1:]
+
+    github_url_match = re.match(
+        r"^(?:https?://)?(?:www\.)?github\.com/(?P<login>[^/]+)(?:/.*)?$",
+        candidate,
+        flags=re.IGNORECASE,
+    )
+    if github_url_match:
+        candidate = github_url_match.group("login")
+
+    ssh_url_match = re.match(
+        r"^git@github\.com:(?P<login>[^/]+)/?.*$",
+        candidate,
+        flags=re.IGNORECASE,
+    )
+    if ssh_url_match:
+        candidate = ssh_url_match.group("login")
+
+    if candidate.endswith(".git"):
+        candidate = candidate[:-4]
+    if candidate.startswith("@"):
+        candidate = candidate[1:]
+
+    return candidate or None
+
+
 def collect_control_plane_paths(workspace_check: dict[str, Any]) -> dict[str, Path]:
     paths: dict[str, Path] = {}
     repos = workspace_check.get("repos", {})
@@ -419,7 +459,7 @@ def collect_control_plane_paths(workspace_check: dict[str, Any]) -> dict[str, Pa
 def build_preflight_check(
     *,
     cwd: Path,
-    expected_github_login: str = DEFAULT_EXPECTED_GITHUB_LOGIN,
+    expected_github_login: str | None = DEFAULT_EXPECTED_GITHUB_LOGIN,
     github_owner: str = DEFAULT_GITHUB_OWNER,
     admin: bool = False,
     target_repo_full_name: str | None = None,
@@ -427,6 +467,7 @@ def build_preflight_check(
 ) -> dict[str, Any]:
     mode = "admin" if admin else "basic"
     checks: list[dict[str, Any]] = []
+    normalized_expected_github_login = normalize_github_login_identifier(expected_github_login)
 
     git_path = shutil.which("git")
     add_preflight_check(
@@ -462,21 +503,29 @@ def build_preflight_check(
 
         user_result = run_command_result(["gh", "api", "user", "--jq", ".login"])
         github_login = user_result.stdout.strip() if user_result.returncode == 0 else None
-        login_ok = github_login == expected_github_login
+        login_ok = (
+            normalized_expected_github_login is not None
+            and github_login is not None
+            and github_login.lower() == normalized_expected_github_login.lower()
+        )
+        if normalized_expected_github_login is None:
+            account_message = (
+                f"No expected GitHub account is configured. {GITHUB_LOGIN_REQUEST_MESSAGE}"
+            )
+        elif login_ok:
+            account_message = f"GitHub account is {github_login}."
+        else:
+            account_message = (
+                "Expected GitHub account "
+                f"{normalized_expected_github_login}, got {github_login or command_message(user_result)}."
+            )
         add_preflight_check(
             checks,
             name="github-account",
             passed=login_ok,
-            message=(
-                f"GitHub account is {github_login}."
-                if login_ok
-                else (
-                    "Expected GitHub account "
-                    f"{expected_github_login}, got {github_login or command_message(user_result)}."
-                )
-            ),
+            message=account_message,
             details={
-                "expected": expected_github_login,
+                "expected": normalized_expected_github_login,
                 "actual": github_login,
             },
         )
@@ -518,8 +567,12 @@ def build_preflight_check(
             checks,
             name="github-account",
             passed=False,
-            message=f"Cannot confirm expected GitHub account {expected_github_login}.",
-            details={"expected": expected_github_login, "actual": None},
+            message=(
+                f"Cannot confirm expected GitHub account {normalized_expected_github_login}."
+                if normalized_expected_github_login
+                else f"Cannot confirm GitHub account because gh CLI is missing. {GITHUB_LOGIN_REQUEST_MESSAGE}"
+            ),
+            details={"expected": normalized_expected_github_login, "actual": None},
         )
         add_preflight_check(
             checks,
@@ -735,7 +788,7 @@ def build_preflight_check(
     return {
         "mode": mode,
         "ready": ready,
-        "expected_github_login": expected_github_login,
+        "expected_github_login": normalized_expected_github_login,
         "github_login": github_login,
         "github_owner": github_owner,
         "target_repo": normalized_target_repo,
@@ -1106,8 +1159,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--expected-github-login",
-        default=os.environ.get("CLEVER_EXPECTED_GITHUB_LOGIN", DEFAULT_EXPECTED_GITHUB_LOGIN),
-        help="Expected GitHub login for gh authenticated operations.",
+        default=os.environ.get("CLEVER_EXPECTED_GITHUB_LOGIN") or DEFAULT_EXPECTED_GITHUB_LOGIN,
+        help=(
+            "Expected GitHub login or profile URL for gh authenticated operations. "
+            "No shared default is assumed; ask the user on first startup."
+        ),
     )
     parser.add_argument(
         "--github-owner",
@@ -1202,7 +1258,10 @@ def print_preflight_check(preflight_check: dict[str, Any]) -> None:
     print(f"mode: {preflight_check['mode']}")
     print(f"ready: {'yes' if preflight_check['ready'] else 'no'}")
     print(f"github-owner: {preflight_check['github_owner']}")
-    print(f"expected-github-login: {preflight_check['expected_github_login']}")
+    print(
+        "expected-github-login: "
+        f"{preflight_check['expected_github_login'] or 'needs-user-input'}"
+    )
     print(f"github-login: {preflight_check['github_login'] or 'unknown'}")
     if preflight_check.get("target_repo"):
         print(f"target-repo: {preflight_check['target_repo']}")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,23 +19,26 @@ If any of these repositories are missing, the workspace is incomplete.
 Do not pretend web links are a substitute for local context.
 Stop and state that the three-repository local workspace is required.
 
-At startup, run this automatic preflight first:
+At startup, ask the current user for their GitHub login or profile URL, then run this automatic preflight first:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 If the session is explicitly about editing the current control-plane repo itself, run:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
 The preflight must verify at least:
 
 - local `git` and `gh` CLIs
 - `gh auth status`
-- authenticated GitHub login, defaulting to `OziinG`
+- authenticated GitHub login explicitly provided by the current user via
+  `CLEVER_EXPECTED_GITHUB_LOGIN` or `--expected-github-login`
 - active membership in the `EVNSolution` GitHub org
 - local three-repository workspace readiness
 - control-plane origin remotes under `EVNSolution/*`
@@ -58,7 +61,8 @@ Before creating a target repo, applying rulesets, or changing GitHub protection
 settings, run admin preflight with the target repo:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py \
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py \
   --cwd "$PWD" \
   --admin-preflight \
   --target-repo-full-name EVNSolution/<target-repo> \
@@ -80,7 +84,8 @@ conversation if the answers are not already present.
 First action:
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 Then apply the result:
@@ -556,7 +561,7 @@ Do not:
 
 The expected operating flow is:
 
-1. Run preflight for the three-repository local workspace and GitHub account
+1. Ask for the current user's GitHub login or profile URL, then run preflight for the three-repository local workspace and GitHub account
 2. Gather the startup frame
    - collect `work_kind`, `architecture_kind`, `session_goal`
    - fill the startup branch state template

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ git clone https://github.com/EVNSolution/clever-context-monorepo.git
 git clone https://github.com/EVNSolution/clever-change-control.git
 
 cd clever-agent-project
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 에이전트 종류별 실행 예시:
@@ -132,7 +133,7 @@ CLEVER를 제대로 실행하려면 아래 조건이 먼저 만족되어야 한�
 - 웹 링크만으로는 충분하지 않다.
 - 3개 중 하나라도 없으면 실행 품질이 크게 저하된다.
 - `gh` CLI가 설치되어 있고 `gh auth status`가 통과해야 한다.
-- 기본 GitHub 계정은 `OziinG`으로 검증한다. 다른 계정을 써야 하면 `CLEVER_EXPECTED_GITHUB_LOGIN` 또는 `--expected-github-login`으로 명시한다.
+- 공용 기본 GitHub 계정은 없다. 첫 실행 때 사용자에게 GitHub login 또는 profile URL을 물어보고, `CLEVER_EXPECTED_GITHUB_LOGIN` 또는 `--expected-github-login`으로 명시한 값과 현재 `gh` 계정을 검증한다.
 - GitHub 계정이 `EVNSolution` org active member인지 확인한다.
 - 세 control-plane repo의 origin은 `EVNSolution/*`이어야 한다.
 - 세 control-plane repo는 public이어야 하고 issue, PR, ruleset 조회가 가능해야 한다.
@@ -143,16 +144,18 @@ CLEVER를 제대로 실행하려면 아래 조건이 먼저 만족되어야 한�
 
 ### Preflight Gate
 
-세션을 시작하기 전에 에이전트는 아래 명령으로 로컬 3레포, `gh auth status`, GitHub 계정, 원격 접근, issue/PR/ruleset 조회 가능 여부를 자동 감지한다.
+세션을 시작하기 전에 에이전트는 사용자에게 GitHub login 또는 profile URL을 물어본 뒤 아래 명령으로 로컬 3레포, `gh auth status`, GitHub login, 원격 접근, issue/PR/ruleset 조회 가능 여부를 자동 감지한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 현재 control-plane 저장소 자체를 직접 수정하는 세션이면 아래처럼 유지보수 모드로 확인한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
 반환된 `preflight_check.ready`가 `false`면 시작 템플릿으로 내려가지 않는다.
@@ -163,7 +166,8 @@ repo 생성, ruleset 적용, 보호 설정처럼 GitHub admin 권한이 필요�
 새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight는 org membership과 token/API 접근을 먼저 확인하고 실제 생성 성공은 `gh repo create` 결과로 확정한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py \
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py \
   --cwd "$PWD" \
   --admin-preflight \
   --target-repo-full-name EVNSolution/<target-repo> \

--- a/docs/guides/session-start-smoke-test.md
+++ b/docs/guides/session-start-smoke-test.md
@@ -51,7 +51,8 @@
 운영 환경에서는 첫 질문 전에 아래 자동 감지 명령을 먼저 돌린다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 이 문서의 시나리오는 그 결과가 `preflight_check.ready=true`이고
@@ -60,7 +61,8 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 현재 control-plane 저장소 자체를 직접 수정하는 세션은 아래처럼 유지보수 모드로 따로 확인한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
 ## 합격 기준

--- a/docs/guides/three-repo-startup-alignment.md
+++ b/docs/guides/three-repo-startup-alignment.md
@@ -122,7 +122,8 @@
 현재 경량 `AGENTS.md`는 아래 명령을 사용한다.
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 이건 3레포가 같은 workspace root 아래 sibling으로 있는 구조를 전제로 한다.

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -84,7 +84,7 @@ gh auth status
 ```
 
 헤드리스 환경에서는 `GH_TOKEN` 환경 변수 또는 `gh auth login --with-token` 방식을 사용할 수 있다.
-CLEVER 기본 계정은 `OziinG`으로 검증한다. 다른 계정을 쓸 때는 `CLEVER_EXPECTED_GITHUB_LOGIN` 또는 `--expected-github-login`을 명시한다.
+공용 CLEVER 기본 계정은 없다. 첫 실행 때 사용자에게 GitHub login 또는 profile URL을 물어보고 `CLEVER_EXPECTED_GITHUB_LOGIN` 또는 `--expected-github-login`으로 명시한다.
 preflight는 `EVNSolution` org active membership도 확인한다.
 
 ## Superpowers 설치
@@ -264,7 +264,8 @@ git fetch --prune origin
 초기 `main` commit과 `dev` push가 끝난 뒤 먼저 admin preflight를 실행한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py \
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py \
   --cwd "$PWD" \
   --admin-preflight \
   --target-repo-full-name <owner>/<repo> \
@@ -284,7 +285,7 @@ scripts/apply-github-rulesets.sh <owner>/<repo>
 - `dev`: PR 경유만 허용하고 direct push를 막는다. 승인 수는 0명이다.
 - 그 외 branch: GitHub ruleset을 적용하지 않는다.
 
-이 작업에는 `gh auth status` 통과, GitHub login `OziinG`, `EVNSolution` org membership, target repo의 GitHub Administration write 권한이 필요하다.
+이 작업에는 `gh auth status` 통과, 사용자가 제공한 GitHub login 또는 profile URL 검증, `EVNSolution` org membership, target repo의 GitHub Administration write 권한이 필요하다.
 새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight는 membership과 API 접근을 먼저 확인하고 실제 생성 성공은 `gh repo create` 결과로 확정한다.
 
 ### 로컬 `main` push 금지 가드
@@ -361,16 +362,18 @@ bootstrap packet의 `target_repo_seed_files` 항목은 위 두 파일을 target 
 
 ## 첫 대화 하드 게이트
 
-첫 질문을 던지기 전에 에이전트는 먼저 로컬 workspace, `gh auth status`, GitHub 계정, 원격 접근, issue/PR/ruleset 조회 가능 여부를 자동 감지한다.
+첫 질문을 던지기 전에 에이전트는 먼저 사용자에게 GitHub login 또는 profile URL을 물어보고 로컬 workspace, `gh auth status`, GitHub login, 원격 접근, issue/PR/ruleset 조회 가능 여부를 자동 감지한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 현재 control-plane 저장소 자체를 직접 수정하는 세션이면 아래처럼 유지보수 모드로 확인한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
 `preflight_check.ready=false`이면 시작 질문으로 내려가지 않고 실패한 check를 먼저 해결한다.

--- a/docs/templates/target-repo-AGENTS.md
+++ b/docs/templates/target-repo-AGENTS.md
@@ -22,23 +22,25 @@
 
 새 target repo에서 팀 작업 자동화, issue/PR 동시작업 판정, ruleset 적용, CODEOWNERS/CI 보강 같은 team-work automation을 시작하기 전에는 control-plane preflight가 먼저 통과되어야 한다.
 
-control-plane workspace의 `clever-agent-project`에서 실행한다.
+control-plane workspace의 `clever-agent-project`에서 실행한다. 첫 실행 때는 사용자에게 GitHub login 또는 profile URL을 물어보고 `CLEVER_EXPECTED_GITHUB_LOGIN`에 넣는다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 repo 생성, ruleset 적용, branch protection 변경처럼 GitHub admin 권한이 필요한 단계는 대상 repo를 지정해 admin preflight를 다시 통과한다.
 
 ```bash
-python3 scripts/bootstrap_clever_work.py \
+CLEVER_EXPECTED_GITHUB_LOGIN="<github-login-or-profile-url>" \
+  python3 scripts/bootstrap_clever_work.py \
   --cwd "$PWD" \
   --admin-preflight \
   --target-repo-full-name <target_repo_full_name> \
   --json
 ```
 
-preflight는 최소한 `gh auth status`, GitHub login `OziinG`, `EVNSolution` org membership, `EVNSolution/*` origin, public repo, issue/PR/ruleset 조회 권한, clean worktree, remote fetch 접근을 확인한다.
+preflight는 최소한 `gh auth status`, 사용자가 제공한 GitHub login 또는 profile URL, `EVNSolution` org membership, `EVNSolution/*` origin, public repo, issue/PR/ruleset 조회 권한, clean worktree, remote fetch 접근을 확인한다.
 새 repo 생성 권한은 destructive create 없이 완전히 증명할 수 없으므로, preflight 통과 후 `gh repo create` 성공 결과를 생성 proof로 본다.
 출력의 `preflight_check.ready=true`를 확인한 뒤에만 구현 계획, repo bootstrap, 동시작업 gate 판정으로 내려간다.
 실패하면 해당 단계로 내려가지 않는다.

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -730,11 +730,11 @@ def test_preflight_check_passes_when_github_account_workspace_and_remotes_are_re
     def fake_run(cmd: list[str], cwd: Path | None = None):
         command_log.append(tuple(cmd))
         if cmd[:3] == ["gh", "api", "user"]:
-            return module.CommandResult(0, "OziinG\n", "")
+            return module.CommandResult(0, "jiinlim\n", "")
         if cmd[:3] == ["gh", "api", "user/memberships/orgs/EVNSolution"]:
             return module.CommandResult(0, json.dumps({"state": "active", "role": "admin"}), "")
         if cmd[:2] == ["gh", "auth"]:
-            return module.CommandResult(0, "Logged in to github.com as OziinG\n", "")
+            return module.CommandResult(0, "Logged in to github.com as jiinlim\n", "")
         if cmd[:3] == ["git", "-C", "/workspace/clever-agent-project"]:
             if cmd[3:] == ["remote", "get-url", "origin"]:
                 return module.CommandResult(
@@ -789,13 +789,13 @@ def test_preflight_check_passes_when_github_account_workspace_and_remotes_are_re
 
     report = module.build_preflight_check(
         cwd=REPO_ROOT,
-        expected_github_login="OziinG",
+        expected_github_login="jiinlim",
         github_owner="EVNSolution",
     )
 
     assert report["ready"] is True
     assert report["mode"] == "basic"
-    assert report["github_login"] == "OziinG"
+    assert report["github_login"] == "jiinlim"
     assert {check["name"]: check["status"] for check in report["checks"]} == {
         "git-cli": "pass",
         "gh-cli": "pass",
@@ -813,7 +813,7 @@ def test_preflight_check_passes_when_github_account_workspace_and_remotes_are_re
     assert ("gh", "api", "user", "--jq", ".login") in command_log
 
 
-def test_preflight_check_fails_before_startup_when_github_login_is_wrong(monkeypatch):
+def test_preflight_check_requires_user_provided_github_login_when_missing(monkeypatch):
     module = load_module()
 
     monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
@@ -838,15 +838,90 @@ def test_preflight_check_fails_before_startup_when_github_login_is_wrong(monkeyp
 
     report = module.build_preflight_check(
         cwd=REPO_ROOT,
-        expected_github_login="OziinG",
+        expected_github_login=None,
+        github_owner="EVNSolution",
+    )
+
+    assert report["ready"] is False
+    assert report["expected_github_login"] is None
+    assert report["github_login"] == "jiinlim"
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["github-account"]["status"] == "fail"
+    assert "Ask the user for their GitHub login or profile URL" in checks["github-account"][
+        "message"
+    ]
+    assert "OziinG" not in checks["github-account"]["message"]
+
+
+def test_preflight_check_accepts_expected_github_profile_url(monkeypatch):
+    module = load_module()
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        module,
+        "build_workspace_check",
+        lambda cwd, *, current_repo_maintenance=False: {
+            "startup_ready": True,
+            "agent_action": "proceed-with-hard-gate",
+            "repos": {},
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "run_command_result",
+        lambda cmd, cwd=None: module.CommandResult(
+            0,
+            "jiinlim\n" if cmd[:3] == ["gh", "api", "user"] else "",
+            "",
+        ),
+    )
+
+    report = module.build_preflight_check(
+        cwd=REPO_ROOT,
+        expected_github_login="https://github.com/jiinlim",
+        github_owner="EVNSolution",
+    )
+
+    assert report["github_login"] == "jiinlim"
+    assert report["expected_github_login"] == "jiinlim"
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["github-account"]["status"] == "pass"
+
+
+def test_preflight_check_fails_before_startup_when_github_login_is_wrong(monkeypatch):
+    module = load_module()
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        module,
+        "build_workspace_check",
+        lambda cwd, *, current_repo_maintenance=False: {
+            "startup_ready": True,
+            "agent_action": "proceed-with-hard-gate",
+            "repos": {},
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "run_command_result",
+        lambda cmd, cwd=None: module.CommandResult(
+            0,
+            "other-user\n" if cmd[:3] == ["gh", "api", "user"] else "",
+            "",
+        ),
+    )
+
+    report = module.build_preflight_check(
+        cwd=REPO_ROOT,
+        expected_github_login="jiinlim",
         github_owner="EVNSolution",
     )
 
     assert report["ready"] is False
     checks = {check["name"]: check for check in report["checks"]}
     assert checks["github-account"]["status"] == "fail"
-    assert "OziinG" in checks["github-account"]["message"]
     assert "jiinlim" in checks["github-account"]["message"]
+    assert "other-user" in checks["github-account"]["message"]
 
 
 def test_admin_preflight_requires_admin_permission_for_target_repo(monkeypatch):
@@ -867,7 +942,7 @@ def test_admin_preflight_requires_admin_permission_for_target_repo(monkeypatch):
         if cmd[:2] == ["gh", "auth"]:
             return module.CommandResult(0, "Logged in\n", "")
         if cmd[:3] == ["gh", "api", "user"]:
-            return module.CommandResult(0, "OziinG\n", "")
+            return module.CommandResult(0, "jiinlim\n", "")
         if cmd[:3] == ["gh", "api", "user/memberships/orgs/EVNSolution"]:
             return module.CommandResult(0, json.dumps({"state": "active", "role": "admin"}), "")
         if cmd[:3] == ["gh", "repo", "view"]:
@@ -895,7 +970,7 @@ def test_admin_preflight_requires_admin_permission_for_target_repo(monkeypatch):
 
     report = module.build_preflight_check(
         cwd=REPO_ROOT,
-        expected_github_login="OziinG",
+        expected_github_login="jiinlim",
         github_owner="EVNSolution",
         admin=True,
         target_repo_full_name="EVNSolution/example-target",
@@ -920,8 +995,11 @@ def test_docs_require_preflight_before_startup_and_admin_repo_bootstrap():
     for text in (readme, agents, skill):
         assert "--preflight" in text
         assert "gh auth status" in text
-        assert "OziinG" in text
+        assert "GitHub login" in text
+        assert "CLEVER_EXPECTED_GITHUB_LOGIN" in text
+        assert "OziinG" not in text
         assert "--admin-preflight" in text
+    assert "OziinG" not in target_agents
     assert "Preflight Gate" in target_agents
     assert "team-work automation" in target_agents
 
@@ -929,8 +1007,6 @@ def test_docs_require_preflight_before_startup_and_admin_repo_bootstrap():
 def test_agent_files_startup_behavior_uses_preflight_gate():
     agent_files = [
         REPO_ROOT / "AGENTS.md",
-        REPO_ROOT.parent / "clever-context-monorepo/AGENTS.md",
-        REPO_ROOT.parent / "clever-change-control/AGENTS.md",
         REPO_ROOT / "docs/templates/target-repo-AGENTS.md",
     ]
 
@@ -939,6 +1015,32 @@ def test_agent_files_startup_behavior_uses_preflight_gate():
         assert "Run the workspace check" not in text
         assert "automatic workspace check" not in text
         assert "preflight_check.ready=true" in text
+
+
+def test_sibling_control_plane_agent_files_point_to_agent_project_for_startup():
+    sibling_agent_files = [
+        REPO_ROOT.parent / "clever-context-monorepo/AGENTS.md",
+        REPO_ROOT.parent / "clever-change-control/AGENTS.md",
+    ]
+
+    for doc_path in sibling_agent_files:
+        text = doc_path.read_text(encoding="utf-8")
+        assert "startup/preflight authority lives in `clever-agent-project`" in text
+        assert "python3 ../clever-agent-project/scripts/bootstrap_clever_work.py" not in text
+        assert "CLEVER_EXPECTED_GITHUB_LOGIN" not in text
+        assert "gh auth status" not in text
+        assert "workspace_check.agent_action" not in text
+
+
+def test_context_governance_keeps_startup_details_in_agent_project():
+    text = (REPO_ROOT.parent / "clever-context-monorepo/docs/root/agent-runtime-governance.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "startup/preflight authority lives in `clever-agent-project`" in text
+    assert "python3 ../clever-agent-project/scripts/bootstrap_clever_work.py" not in text
+    assert "CLEVER_EXPECTED_GITHUB_LOGIN" not in text
+    assert "gh auth status" not in text
 
 
 def test_startup_guides_use_preflight_command_not_legacy_workspace_cli():

--- a/tests/test_gitignore_whitelist.py
+++ b/tests/test_gitignore_whitelist.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTROL_PLANE_REPOS = [
+    REPO_ROOT,
+    REPO_ROOT.parent / "clever-context-monorepo",
+    REPO_ROOT.parent / "clever-change-control",
+]
 
 
 def test_tracked_files_are_whitelisted_from_default_ignore():
@@ -40,3 +45,24 @@ def test_tracked_files_are_whitelisted_from_default_ignore():
             blocked.append(f"{path} matched {pattern}")
 
     assert blocked == []
+
+
+def test_control_plane_repos_ignore_ds_store_files():
+    for repo_path in CONTROL_PLANE_REPOS:
+        ignored = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_path),
+                "check-ignore",
+                "-v",
+                "--",
+                ".DS_Store",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert ignored.returncode == 0, repo_path
+        assert ".DS_Store" in ignored.stdout


### PR DESCRIPTION
## change id

- chg-20260428-001

## 관련 issue

- EVNSolution/clever-change-control#33
- supersedes EVNSolution/clever-agent-project#18

## 대상 repo/service

- EVNSolution/clever-agent-project
- CLEVER startup/preflight helper and docs

## 변경 내용

- shared `OziinG` GitHub account default 제거
- 사용자별 GitHub login/profile URL을 `CLEVER_EXPECTED_GITHUB_LOGIN` 또는 `--expected-github-login`으로 받도록 preflight 변경
- GitHub login/profile URL normalization 추가
- startup/preflight 상세 지침을 `clever-agent-project`에만 유지
- sibling repo가 startup 상세를 복제하지 않도록 회귀 테스트 추가
- 3개 control-plane repo의 `.DS_Store` ignore 검증 추가

## PR Scope Grouping Gate

- grouping decision: `split-required`
- same document/operating-rule cleanup: yes, but spans separate repositories
- same validation command: `python3 -m pytest -q`
- different app/service/contract surface: yes, three control-plane repositories
- merge order dependency: merge this with companion PRs for docs pointers
- rollback unit: this repository's preflight behavior and docs

## 테스트 여부

- `python3 -m pytest -q` → `60 passed, 2 skipped`
- `python3 -m compileall -q .agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py tests/test_bootstrap_clever_work.py tests/test_gitignore_whitelist.py`
- `git diff --check` across all three control-plane repos

## 검수 포인트

- `DEFAULT_EXPECTED_GITHUB_LOGIN` is `None`
- missing expected login fails with a user GitHub login/profile URL prompt
- `https://github.com/<login>` is accepted and normalized
- active docs/code no longer assume `OziinG`
- sibling repo startup details remain out of this repo's companion docs

## rollout/rollback 영향

- rollout: new CLEVER sessions must provide the expected GitHub login/profile URL before preflight passes
- rollback: restore the previous default account behavior, not recommended for shared devices

## Concurrent Work Gate

- parallel work decision: `allowed-with-non-overlap`
- target repo issue: n/a
- clever-change-control issue: EVNSolution/clever-change-control#33
- open PR checked: supersedes EVNSolution/clever-agent-project#18
- conflict candidates: EVNSolution/clever-context-monorepo#17 merged first
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: yes
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: companion PR EVNSolution/clever-context-monorepo#19
- linked issue close evidence: EVNSolution/clever-change-control#33 remains open until companion PRs are resolved
