### PR TITLE
[일반 개발][수정] GitHub Pages 시작 도우미 hotfix

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,33 +2,64 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate static Pages site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Serve docs and verify pages open
+        run: |
+          python3 -m http.server 8000 --directory docs > /tmp/clever-pages.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid"' EXIT
+
+          for _ in {1..20}; do
+            if curl -fsS http://127.0.0.1:8000/ -o /tmp/pages-root.html; then
+              break
+            fi
+            sleep 0.5
+          done
+
+          curl -fsS http://127.0.0.1:8000/ -o /tmp/pages-root.html
+          curl -fsS http://127.0.0.1:8000/start/ -o /tmp/pages-start.html
+          grep -q "CLEVER 시작 도우미" /tmp/pages-root.html
+          grep -q "url=start/" /tmp/pages-root.html
+          grep -q "CLEVER 시작 도우미" /tmp/pages-start.html
+          grep -q "copyOutput" /tmp/pages-start.html
+          grep -q "navigator.clipboard.writeText" /tmp/pages-start.html
+
   deploy:
+    needs: validate
+    if: ${{ github.ref == 'refs/heads/main' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/tests/test_github_pages_start_wizard.py
+++ b/tests/test_github_pages_start_wizard.py
@@ -77,12 +77,25 @@ def test_start_wizard_output_is_clone_ready_and_copyable():
 def test_pages_workflow_publishes_docs_directory():
     workflow = read(".github/workflows/pages.yml")
 
-    assert "actions/configure-pages@v5" in workflow
-    assert "actions/upload-pages-artifact@v4" in workflow
-    assert "actions/deploy-pages@v4" in workflow
+    assert "actions/configure-pages@v6" in workflow
+    assert "actions/upload-pages-artifact@v5" in workflow
+    assert "actions/deploy-pages@v5" in workflow
     assert "path: docs" in workflow
     assert "pages: write" in workflow
     assert "id-token: write" in workflow
+
+
+def test_pages_workflow_validates_branch_site_before_main_deploy():
+    workflow = read(".github/workflows/pages.yml")
+
+    assert "pull_request:" in workflow
+    assert "validate:" in workflow
+    assert "python3 -m http.server 8000 --directory docs" in workflow
+    assert "http://127.0.0.1:8000/" in workflow
+    assert "http://127.0.0.1:8000/start/" in workflow
+    assert "copyOutput" in workflow
+    assert "needs: validate" in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
 
 
 def test_gitignore_allows_pages_and_wizard_files():


### PR DESCRIPTION
## change id

- chg-20260428-007

## 관련 issue

- EVNSolution/clever-change-control#36

## 대상 repo/service

- `clever-agent-project`
- GitHub Pages 시작 도우미 / `.github/workflows/pages.yml`

## 변경 내용

- GitHub Pages workflow를 `validate`와 `deploy`로 분리했습니다.
- 브랜치/PR run에서는 `docs`를 Actions runner 안에서 HTTP 서버로 띄우고 `/`, `/start/` 접속 및 핵심 marker를 검증합니다.
- 실제 GitHub Pages deploy는 `main`에서만 실행되도록 제한했습니다.
- Pages actions를 Node 24 호환 최신 major로 올렸습니다.
  - `actions/configure-pages@v6`
  - `actions/upload-pages-artifact@v5`
  - `actions/deploy-pages@v5`

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: GitHub Pages workflow hotfix
- same validation command: `python3 -m pytest -q`, Pages workflow branch run
- different app/service/contract surface: 없음
- merge order dependency: 없음
- rollback unit: `.github/workflows/pages.yml`, `tests/test_github_pages_start_wizard.py`

같은 issue 안의 같은 운영 문서/절차 정리이고 같은 검증으로 충분하면 `single-pr`로 둔다.
앱, 서비스, 계약 표면, merge 순서, 롤백 단위가 다르면 `split-required`로 둔다.

## 테스트 여부

- `python3 -m pytest -q` → 74 passed, 2 skipped
- `python3 -m compileall -q scripts tests .agent/skills/bootstrap-clever-work/scripts` → pass
- `git diff --check` → pass
- 브랜치 action: https://github.com/EVNSolution/clever-agent-project/actions/runs/25042189895 → success
- live Pages 현재 main 배포본 확인:
  - `https://evnsolution.github.io/clever-agent-project/` → 200
  - `https://evnsolution.github.io/clever-agent-project/start/` → 200

## 검수 포인트

- PR/브랜치 run이 protected `github-pages` environment 배포를 시도하지 않는지
- main merge 후 deploy job이 실행되는지
- `/start/` 페이지가 200으로 열리고 copy text marker가 남아 있는지
- main deploy run에서 Node.js 20 action deprecation warning이 사라졌는지

## rollout/rollback 영향

- rollout: main merge 후 GitHub Pages workflow가 static docs를 검증하고 Pages에 배포합니다.
- rollback: workflow action pin과 validate/deploy 분리를 이전 상태로 되돌리면 됩니다.

## Concurrent Work Gate

- parallel work decision: `done`
- target repo issue: EVNSolution/clever-change-control#36
- clever-change-control issue: EVNSolution/clever-change-control#36
- open PR checked: none before this PR
- conflict candidates: `.github/workflows/pages.yml`, `tests/test_github_pages_start_wizard.py`
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: n/a
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: not-needed
- linked issue close evidence: merge 후 main Pages deploy 검증 결과로 남김
