### PR TITLE
[일반 개발][변경] 시작 도우미 입력 범위 최소화

### DIFF
--- a/docs/start/index.html
+++ b/docs/start/index.html
@@ -69,9 +69,6 @@
     .output { min-height: 420px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre; }
     .hint { font-size: 0.92rem; color: var(--muted); }
     .target { padding: 12px 14px; border-radius: 12px; background: #f2f4f7; color: var(--ink); }
-    .subpanel { border: 1px solid var(--line); border-radius: 16px; padding: 16px; background: #fbfcff; margin-top: 14px; }
-    .subpanel h3 { margin: 0 0 8px; font-size: 1.05rem; }
-    .hidden { display: none !important; }
     .ok { color: var(--ok); font-weight: 700; }
     .warn { color: var(--danger); font-weight: 700; }
     code { background: #eef2f7; padding: 2px 5px; border-radius: 5px; }
@@ -141,52 +138,23 @@
 
     <section class="panel" aria-labelledby="info-title">
       <h2 id="info-title">3. 대상 정보</h2>
-      <p>선택한 작업 성격과 대상 범위에 맞는 카드만 보여줍니다. 신규 개발은 새로 만들 대상 중심으로, 기존 작업은 이미 있는 대상 중심으로 적습니다.</p>
-
-      <div class="subpanel" data-target-card="new">
-        <h3>새로 만들 대상 정보</h3>
-        <p class="hint">새 개발에는 아직 repo나 화면/API가 없을 수 있습니다. 만들 대상의 이름과 시작에 필요한 단서만 적습니다.</p>
-        <div class="grid">
-          <div><label for="newTargetName">새 대상 이름/가칭</label><input id="newTargetName" data-field="newTargetName" placeholder="예: 파트너 포털, 인증 v2"></div>
-          <div><label for="newRepoCandidate">만들 repo/service 후보</label><input id="newRepoCandidate" data-field="newRepoCandidate" placeholder="예: 새 repo 필요, 기존 monorepo 안에 추가"></div>
-          <div><label for="newServiceGoal">대상 사용자/목적</label><input id="newServiceGoal" data-field="newServiceGoal" placeholder="누가 무엇을 하게 만들지"></div>
-          <div><label for="newUserFlow">첫 화면/API/흐름 후보</label><input id="newUserFlow" data-field="newUserFlow" placeholder="예: 로그인 → 신청서 작성 → 승인"></div>
-        </div>
-        <label for="newSeedInfo">초기 입력/자료</label>
-        <textarea id="newSeedInfo" data-field="newSeedInfo" placeholder="정책, 예시 데이터, 레퍼런스, 반드시 포함할 기능을 적어 주세요."></textarea>
-      </div>
-
-      <div class="subpanel" data-target-card="existing">
-        <h3>기존 대상 정보</h3>
-        <p class="hint">이미 있는 앱/서비스/기능을 고치는 작업이면 repo, 화면, API, DB/model, 문서처럼 찾을 수 있는 위치를 적습니다.</p>
-        <div class="grid">
-          <div><label for="repo">repo</label><input id="repo" data-field="repo" placeholder="기존 repo 이름 또는 URL"></div>
-          <div><label for="service">service/app</label><input id="service" data-field="service" placeholder="기존 service/app 이름"></div>
-          <div><label for="screen">화면</label><input id="screen" data-field="screen"></div>
-          <div><label for="api">API</label><input id="api" data-field="api"></div>
-          <div><label for="db">DB/model</label><input id="db" data-field="db"></div>
-          <div><label for="docs">문서</label><input id="docs" data-field="docs"></div>
-        </div>
-      </div>
-
-      <div class="subpanel" data-target-card="unknown">
-        <h3>대상 정보가 아직 애매함</h3>
-        <p class="hint">새로 만들지, 기존 것을 고칠지 아직 모르면 지금 알고 있는 단서만 적습니다. 에이전트가 먼저 분류합니다.</p>
-        <label for="targetClues">알고 있는 대상 단서</label>
-        <textarea id="targetClues" data-field="targetClues" placeholder="예: 고객이 쓰는 관리자 쪽, 결제 관련, 최근 에러가 난 화면 등"></textarea>
-      </div>
-
-      <label for="references">issue/PR/Figma/회의 메모/에러 로그</label>
-      <textarea id="references" data-field="references" placeholder="관련 링크나 로그를 붙여 넣으세요."></textarea>
+      <p>대상을 정확히 분류하려고 하지 말고, 에이전트가 읽고 판단할 수 있게 한 덩어리로 적습니다.</p>
+      <label for="serviceAlias">서비스 이름(가칭)</label>
+      <input id="serviceAlias" data-field="serviceAlias" placeholder="신규 서비스면 예: 파트너 포털, 결제 정산 서비스. 아니면 비워도 됩니다.">
+      <label for="targetInfo">대상 정보</label>
+      <textarea id="targetInfo" data-field="targetInfo" placeholder="예시 1: 기획문서는 있어서 repo만 만들면 바로 시작 가능.
+예시 2: 바이브코딩이라 대화로 진행.
+예시 3: 다른 MSA 서비스에 있는 기능을 가져와서 새 서비스를 만들거야."></textarea>
+      <p class="hint">repo, 화면, API, DB/model, Figma, 회의 메모, 에러 로그가 있으면 이 칸에 같이 붙여 넣으세요.</p>
     </section>
 
     <section class="panel" aria-labelledby="state-title">
       <h2 id="state-title">4. 현재 상태</h2>
-      <div class="grid three">
-        <div><label for="alreadyDone">이미 되어 있는 것</label><textarea id="alreadyDone" data-field="alreadyDone"></textarea></div>
-        <div><label for="missing">아직 없는 것</label><textarea id="missing" data-field="missing"></textarea></div>
-        <div><label for="checkFirst">먼저 확인해야 할 것</label><textarea id="checkFirst" data-field="checkFirst"></textarea></div>
-      </div>
+      <p>이미 된 것/없는 것/먼저 볼 것을 나누려 하지 말고 지금 아는 상태만 적습니다.</p>
+      <label for="currentState">현재 상태</label>
+      <textarea id="currentState" data-field="currentState" placeholder="예시 1: 기획문서는 있음. repo 생성과 기본 세팅부터 필요.
+예시 2: 아직 정해진 건 거의 없고 대화로 만들면서 결정.
+예시 3: 기존 MSA 서비스 구현을 참고해서 새 서비스로 분리하고 싶음."></textarea>
     </section>
 
     <section class="panel" aria-labelledby="caution-title">
@@ -228,22 +196,9 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json`;
       workNature: "아직 모름",
       targetScope: "아직 모름",
       goalLevel: "아직 모름",
-      newTargetName: "",
-      newRepoCandidate: "",
-      newServiceGoal: "",
-      newUserFlow: "",
-      newSeedInfo: "",
-      targetClues: "",
-      repo: "",
-      service: "",
-      screen: "",
-      api: "",
-      db: "",
-      docs: "",
-      references: "",
-      alreadyDone: "",
-      missing: "",
-      checkFirst: "",
+      serviceAlias: "",
+      targetInfo: "",
+      currentState: "",
       mustKeep: "",
       avoid: "",
       dontTouch: "",
@@ -256,38 +211,6 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json`;
       "Terminal CLI": "clever-agent-workspace/clever-agent-project 경로에서 CLI 에이전트를 연 뒤, 프롬프트 입력창에 이 내용을 붙여넣어 주세요."
     };
 
-    const existingTargetScopes = [
-      "기존 앱/서비스/기능",
-      "화면/UI",
-      "API",
-      "DB/model",
-      "CI/CD 또는 배포 workflow",
-      "문서/운영 설정"
-    ];
-
-    const existingWorkNatures = [
-      "기존 기능 확장/수정",
-      "버그 수정",
-      "리팩터링/구조 개선",
-      "문서/설정/운영 정리"
-    ];
-
-    function targetInfoMode() {
-      if (state.targetScope === "새 앱/서비스/기능") return "new";
-      if (existingTargetScopes.includes(state.targetScope)) return "existing";
-      if (state.workNature === "신규 개발") return "new";
-      if (existingWorkNatures.includes(state.workNature)) return "existing";
-      return "unknown";
-    }
-
-    function targetInfoModeLabel() {
-      return {
-        new: "새로 만들 대상",
-        existing: "기존 대상",
-        unknown: "아직 모르는 대상"
-      }[targetInfoMode()];
-    }
-
     function valueOrUnknown(value) {
       const trimmed = String(value || "").trim();
       return trimmed || "아직 모름";
@@ -298,48 +221,11 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json`;
     }
 
     function targetInfoBlock() {
-      const mode = targetInfoMode();
-      const common = [
-        "4. 대상 정보 입력 방향",
-        line("방향", targetInfoModeLabel()),
-        line("선택 근거", `작업 성격=${state.workNature}, 대상 범위=${state.targetScope}`)
-      ];
-
-      if (mode === "new") {
-        return [
-          ...common,
-          "",
-          "[새로 만들 대상]",
-          line("새 대상 이름/가칭", state.newTargetName),
-          line("만들 repo/service 후보", state.newRepoCandidate),
-          line("대상 사용자/목적", state.newServiceGoal),
-          line("첫 화면/API/흐름 후보", state.newUserFlow),
-          line("초기 입력/자료", state.newSeedInfo),
-          line("issue/PR/Figma/회의 메모/에러 로그", state.references)
-        ].join("\n");
-      }
-
-      if (mode === "existing") {
-        return [
-          ...common,
-          "",
-          "[기존 대상]",
-          line("repo", state.repo),
-          line("service/app", state.service),
-          line("화면", state.screen),
-          line("API", state.api),
-          line("DB/model", state.db),
-          line("문서", state.docs),
-          line("issue/PR/Figma/회의 메모/에러 로그", state.references)
-        ].join("\n");
-      }
-
       return [
-        ...common,
-        "",
-        "[아직 모르는 대상 단서]",
-        line("알고 있는 대상 단서", state.targetClues),
-        line("issue/PR/Figma/회의 메모/에러 로그", state.references)
+        "4. 대상 정보 입력",
+        "- 에이전트 판단 기준: 에이전트가 이 내용을 읽고 새 개발인지 기존 서비스 작업인지 판단하세요.",
+        line("서비스 이름(가칭)", state.serviceAlias),
+        line("대상 정보", state.targetInfo)
       ].join("\n");
     }
 
@@ -381,10 +267,8 @@ preflight가 통과하면 아래 입력을 startup branch state로 정규화하�
 
 ${targetInfoBlock()}
 
-5. 현재 상태를 알고 있나요? 모르면 \`아직 모름\`으로 둬도 됩니다.
-${line("이미 되어 있는 것", state.alreadyDone)}
-${line("아직 없는 것", state.missing)}
-${line("먼저 확인해야 할 것", state.checkFirst)}
+5. 현재 상태 입력
+${line("현재 상태", state.currentState)}
 
 6. 주의할 점이 있나요? 없으면 비워도 됩니다.
 ${line("꼭 지킬 것", state.mustKeep)}
@@ -397,10 +281,6 @@ ${line("보안/운영/배포 관련 주의사항", state.opsSecurity)}
     function render() {
       document.querySelectorAll(".chip[data-field]").forEach((button) => {
         button.setAttribute("aria-pressed", String(state[button.dataset.field] === button.dataset.value));
-      });
-      const mode = targetInfoMode();
-      document.querySelectorAll("[data-target-card]").forEach((card) => {
-        card.classList.toggle("hidden", card.dataset.targetCard !== mode);
       });
       document.getElementById("copyOutput").value = buildOutput();
       document.getElementById("pasteTarget").textContent = pasteTargets[state.surface] || pasteTargets.Application;

--- a/tests/test_github_pages_start_wizard.py
+++ b/tests/test_github_pages_start_wizard.py
@@ -47,30 +47,44 @@ def test_start_wizard_collects_environment_requirements_and_context():
         "작업 성격",
         "대상 범위",
         "목표 수준",
-        "repo",
-        "service/app",
-        "issue/PR/Figma/회의 메모/에러 로그",
+        "대상 정보",
+        "서비스 이름(가칭)",
+        "현재 상태",
         "꼭 지킬 것",
         "건드리면 안 되는 범위",
     ]:
         assert field in html
 
 
-def test_start_wizard_target_info_switches_by_selected_context():
+def test_start_wizard_uses_minimal_target_and_state_textareas():
     html = read("docs/start/index.html")
 
-    assert "새로 만들 대상 정보" in html
-    assert "기존 대상 정보" in html
-    assert 'data-target-card="new"' in html
-    assert 'data-target-card="existing"' in html
-    assert 'data-target-card="unknown"' in html
-    assert "function targetInfoMode()" in html
-    assert "신규 개발" in html
-    assert "새 앱/서비스/기능" in html
-    assert "기존 기능 확장/수정" in html
-    assert "기존 앱/서비스/기능" in html
-    assert "대상 정보 입력 방향" in html
-    assert "선택한 작업 성격과 대상 범위에 맞는 카드만 보여줍니다" in html
+    assert 'id="targetInfo" data-field="targetInfo"' in html
+    assert 'id="serviceAlias" data-field="serviceAlias"' in html
+    assert 'id="currentState" data-field="currentState"' in html
+    assert "기획문서는 있어서 repo만 만들면 바로 시작 가능" in html
+    assert "바이브코딩이라 대화로 진행" in html
+    assert "다른 MSA 서비스에 있는 기능을 가져와서 새 서비스를 만들거야" in html
+    assert "에이전트가 이 내용을 읽고 새 개발인지 기존 서비스 작업인지 판단하세요" in html
+    assert "대상 정보 입력" in html
+    assert "현재 상태 입력" in html
+
+    removed_detailed_fields = [
+        'data-target-card="new"',
+        'data-target-card="existing"',
+        'function targetInfoMode()',
+        'data-field="repo"',
+        'data-field="service"',
+        'data-field="screen"',
+        'data-field="api"',
+        'data-field="db"',
+        'data-field="docs"',
+        'data-field="alreadyDone"',
+        'data-field="missing"',
+        'data-field="checkFirst"',
+    ]
+    for removed in removed_detailed_fields:
+        assert removed not in html
 
 
 def test_start_wizard_output_is_clone_ready_and_copyable():


### PR DESCRIPTION
## change id

- chg-20260428-009

## 관련 issue

- EVNSolution/clever-change-control#38

## 대상 repo/service

- `clever-agent-project`
- GitHub Pages 시작 도우미 `docs/start/`

## 변경 내용

- `대상 정보`를 상세 카드/필드 구조에서 단일 텍스트 입력으로 줄였습니다.
- 신규 서비스 시작에 필요한 최소 정보만 따로 받을 수 있게 `서비스 이름(가칭)`만 남겼습니다.
- `현재 상태`도 `이미 되어 있는 것` / `아직 없는 것` / `먼저 확인해야 할 것` 분리 대신 단일 텍스트 박스로 줄였습니다.
- placeholder에 실제 시작 상황 예시를 넣었습니다.
  - 기획문서는 있어서 repo만 만들면 바로 시작 가능
  - 바이브코딩이라 대화로 진행
  - 다른 MSA 서비스에 있는 기능을 가져와서 새 서비스를 만들 예정
- copy text는 에이전트가 대상 정보를 읽고 새 개발/기존 서비스 작업 여부를 판단하도록 정리했습니다.

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: GitHub Pages 시작 도우미 입력 UX 단순화
- same validation command: `python3 -m pytest -q`, Pages workflow validate job
- different app/service/contract surface: 없음
- merge order dependency: 없음
- rollback unit: `docs/start/index.html`, `tests/test_github_pages_start_wizard.py`

같은 issue 안의 같은 운영 문서/절차 정리이고 같은 검증으로 충분하면 `single-pr`로 둔다.
앱, 서비스, 계약 표면, merge 순서, 롤백 단위가 다르면 `split-required`로 둔다.

## 테스트 여부

- `python3 -m pytest -q` → 75 passed, 2 skipped
- `python3 -m compileall -q scripts tests .agent/skills/bootstrap-clever-work/scripts` → pass
- `node --check /tmp/clever-start-wizard.js` → pass
- `node /tmp/wizard-runtime-check.js` → pass
- local docs HTTP server root and `/start/` marker check → pass
- `git diff --check` → pass
- branch Pages validate run: https://github.com/EVNSolution/clever-agent-project/actions/runs/25043372584 → success

## 검수 포인트

- `대상 정보`가 단일 textarea 중심인지
- 신규 서비스는 `서비스 이름(가칭)` 정도만 별도 수집하는지
- `현재 상태`가 단일 textarea인지
- copy text에 에이전트 판단 기준과 단일 입력값이 들어가는지

## rollout/rollback 영향

- rollout: main merge 후 GitHub Pages 시작 도우미가 더 적은 입력만 요구합니다.
- rollback: PR diff를 되돌리면 이전 카드/상세 필드 구조로 돌아갑니다.

## Concurrent Work Gate

- parallel work decision: `done`
- target repo issue: EVNSolution/clever-change-control#38
- clever-change-control issue: EVNSolution/clever-change-control#38
- open PR checked: none for this branch before PR creation
- conflict candidates: `docs/start/index.html`, `tests/test_github_pages_start_wizard.py`
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: n/a
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: not-needed
- linked issue close evidence: merge 후 main Pages 검증 결과로 남김
