### PR TITLE
[일반 개발][수정] 시작 도우미 대상 정보 예시 수정

### DIFF
--- a/docs/start/index.html
+++ b/docs/start/index.html
@@ -142,9 +142,9 @@
       <label for="serviceAlias">서비스 이름(가칭)</label>
       <input id="serviceAlias" data-field="serviceAlias" placeholder="신규 서비스면 예: 파트너 포털, 결제 정산 서비스. 아니면 비워도 됩니다.">
       <label for="targetInfo">대상 정보</label>
-      <textarea id="targetInfo" data-field="targetInfo" placeholder="예시 1: 기획문서는 있어서 repo만 만들면 바로 시작 가능.
-예시 2: 바이브코딩이라 대화로 진행.
-예시 3: 다른 MSA 서비스에 있는 기능을 가져와서 새 서비스를 만들거야."></textarea>
+      <textarea id="targetInfo" data-field="targetInfo" placeholder="예시 1: 신규 정산 서비스. 기존 billing-service의 정산 계산 로직을 참고하되 독립 서비스로 만들고 싶음.
+예시 2: 관리자 화면의 고객 상세 &gt; 결제 내역 탭. API는 GET /admin/customers/{id}/payments 쪽으로 보임.
+예시 3: 모바일 앱 로그인 후 온보딩 화면. Figma 링크와 회의 메모는 이 칸에 같이 붙임."></textarea>
       <p class="hint">repo, 화면, API, DB/model, Figma, 회의 메모, 에러 로그가 있으면 이 칸에 같이 붙여 넣으세요.</p>
     </section>
 

--- a/tests/test_github_pages_start_wizard.py
+++ b/tests/test_github_pages_start_wizard.py
@@ -62,9 +62,20 @@ def test_start_wizard_uses_minimal_target_and_state_textareas():
     assert 'id="targetInfo" data-field="targetInfo"' in html
     assert 'id="serviceAlias" data-field="serviceAlias"' in html
     assert 'id="currentState" data-field="currentState"' in html
-    assert "기획문서는 있어서 repo만 만들면 바로 시작 가능" in html
-    assert "바이브코딩이라 대화로 진행" in html
-    assert "다른 MSA 서비스에 있는 기능을 가져와서 새 서비스를 만들거야" in html
+    for target_example in [
+        "신규 정산 서비스. 기존 billing-service의 정산 계산 로직을 참고하되 독립 서비스로 만들고 싶음",
+        "관리자 화면의 고객 상세 &gt; 결제 내역 탭",
+        "모바일 앱 로그인 후 온보딩 화면",
+    ]:
+        assert target_example in html
+
+    target_placeholder = html.split('id="targetInfo" data-field="targetInfo"', 1)[1].split('</textarea>', 1)[0]
+    for state_example in [
+        "기획문서는 있어서 repo만 만들면 바로 시작 가능",
+        "바이브코딩이라 대화로 진행",
+        "다른 MSA 서비스에 있는 기능을 가져와서 새 서비스를 만들거야",
+    ]:
+        assert state_example not in target_placeholder
     assert "에이전트가 이 내용을 읽고 새 개발인지 기존 서비스 작업인지 판단하세요" in html
     assert "대상 정보 입력" in html
     assert "현재 상태 입력" in html
@@ -85,6 +96,18 @@ def test_start_wizard_uses_minimal_target_and_state_textareas():
     ]
     for removed in removed_detailed_fields:
         assert removed not in html
+
+
+def test_start_wizard_current_state_placeholder_uses_status_examples():
+    html = read("docs/start/index.html")
+
+    current_state_placeholder = html.split('id="currentState" data-field="currentState"', 1)[1].split('</textarea>', 1)[0]
+    for state_example in [
+        "기획문서는 있음. repo 생성과 기본 세팅부터 필요",
+        "아직 정해진 건 거의 없고 대화로 만들면서 결정",
+        "기존 MSA 서비스 구현을 참고해서 새 서비스로 분리하고 싶음",
+    ]:
+        assert state_example in current_state_placeholder
 
 
 def test_start_wizard_output_is_clone_ready_and_copyable():


### PR DESCRIPTION
## change id

- chg-20260428-010

## 관련 issue

- EVNSolution/clever-change-control#39

## 대상 repo/service

- `clever-agent-project`
- GitHub Pages 시작 도우미 `docs/start/`

## 변경 내용

- `대상 정보` placeholder가 현재상태/진행방식 예시를 반복하던 문제를 수정했습니다.
- 대상 자체를 설명하는 예시로 교체했습니다.
  - 신규 정산 서비스 + 기존 `billing-service` 참고
  - 관리자 화면 고객 상세 > 결제 내역 탭 + 관련 API 단서
  - 모바일 앱 로그인 후 온보딩 화면 + Figma/회의 메모 단서
- 테스트에서 `targetInfo` placeholder에 현재상태 예시가 들어가지 않도록 막았습니다.

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: GitHub Pages 시작 도우미 placeholder hotfix
- same validation command: `python3 -m pytest -q`, Pages workflow validate job
- different app/service/contract surface: 없음
- merge order dependency: 없음
- rollback unit: `docs/start/index.html`, `tests/test_github_pages_start_wizard.py`

같은 issue 안의 같은 운영 문서/절차 정리이고 같은 검증으로 충분하면 `single-pr`로 둔다.
앱, 서비스, 계약 표면, merge 순서, 롤백 단위가 다르면 `split-required`로 둔다.

## 테스트 여부

- `python3 -m pytest -q` → 76 passed, 2 skipped
- `python3 -m compileall -q scripts tests .agent/skills/bootstrap-clever-work/scripts` → pass
- `node --check /tmp/clever-start-wizard.js` → pass
- local docs HTTP server root and `/start/` marker check → pass
- `git diff --check` → pass
- branch Pages validate run: https://github.com/EVNSolution/clever-agent-project/actions/runs/25044310743 → success

## 검수 포인트

- `대상 정보` 예시가 대상 자체를 설명하는지
- `현재 상태` 예시와 같은 문장이 `targetInfo` placeholder에 들어가지 않는지
- 단일 텍스트 입력 구조는 유지되는지

## rollout/rollback 영향

- rollout: main merge 후 GitHub Pages 시작 도우미의 placeholder 문구만 바뀝니다.
- rollback: placeholder diff를 되돌리면 됩니다.

## Concurrent Work Gate

- parallel work decision: `done`
- target repo issue: EVNSolution/clever-change-control#39
- clever-change-control issue: EVNSolution/clever-change-control#39
- open PR checked: none for this branch before PR creation
- conflict candidates: `docs/start/index.html`, `tests/test_github_pages_start_wizard.py`
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: n/a
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: not-needed
- linked issue close evidence: merge 후 main Pages 검증 결과로 남김
