### PR TITLE
[일반 개발][변경] 시작 도우미 workspace 폴더 선택 추가

### DIFF
--- a/docs/start/index.html
+++ b/docs/start/index.html
@@ -92,6 +92,11 @@
       </div>
       <label for="workspace">원하는 workspace 위치</label>
       <input id="workspace" data-field="workspace" placeholder="예: ~/clever-agent-workspace 또는 아직 모름">
+      <div class="actions">
+        <button id="chooseWorkspaceButton" class="secondary" type="button">폴더 선택</button>
+        <span id="workspacePickerStatus" class="hint" role="status"></span>
+      </div>
+      <p class="hint">브라우저가 지원하면 실제 폴더 선택 패널이 열립니다. 보안상 전체 로컬 경로 대신 선택한 폴더 이름이 들어갈 수 있으니, 필요하면 직접 수정하세요.</p>
       <p class="hint">프롬프트에는 3개 repo가 있는지 확인하고, 없는 repo만 clone하는 명령이 포함됩니다.</p>
     </section>
 
@@ -205,6 +210,8 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json`;
       opsSecurity: ""
     };
 
+    let workspaceDirectoryHandle = null;
+
     const pasteTargets = {
       "Application": "앱형 에이전트의 새 대화창에 이 프롬프트를 복사해서 붙여넣어 주세요.",
       "VS Code Extension": "VS Code에서 workspace를 연 뒤, VS Code Extension 채팅창에 이 프롬프트를 복사해서 붙여넣어 주세요.",
@@ -278,6 +285,38 @@ ${line("보안/운영/배포 관련 주의사항", state.opsSecurity)}
 `;
     }
 
+    function setWorkspacePickerStatus(message, className = "hint") {
+      const status = document.getElementById("workspacePickerStatus");
+      status.textContent = message;
+      status.className = className;
+    }
+
+    async function chooseWorkspaceDirectory() {
+      if (!("showDirectoryPicker" in window)) {
+        setWorkspacePickerStatus("폴더 선택을 지원하지 않는 브라우저입니다. workspace 위치를 직접 입력하세요.", "warn");
+        return;
+      }
+
+      try {
+        const directoryHandle = await window.showDirectoryPicker({
+          id: "clever-agent-workspace",
+          mode: "read",
+          startIn: "documents"
+        });
+        workspaceDirectoryHandle = directoryHandle;
+        state.workspace = directoryHandle.name;
+        document.getElementById("workspace").value = directoryHandle.name;
+        setWorkspacePickerStatus(`선택한 폴더: ${directoryHandle.name}. 전체 로컬 경로 대신 선택한 폴더 이름을 입력했습니다. 필요하면 직접 수정하세요.`, "ok");
+        render();
+      } catch (error) {
+        if (error && error.name === "AbortError") {
+          setWorkspacePickerStatus("폴더 선택을 취소했습니다.", "hint");
+          return;
+        }
+        setWorkspacePickerStatus("폴더 선택을 열 수 없습니다. workspace 위치를 직접 입력하세요.", "warn");
+      }
+    }
+
     function render() {
       document.querySelectorAll(".chip[data-field]").forEach((button) => {
         button.setAttribute("aria-pressed", String(state[button.dataset.field] === button.dataset.value));
@@ -300,6 +339,8 @@ ${line("보안/운영/배포 관련 주의사항", state.opsSecurity)}
       });
     });
 
+    document.getElementById("chooseWorkspaceButton").addEventListener("click", chooseWorkspaceDirectory);
+
     document.getElementById("copyButton").addEventListener("click", async () => {
       const output = document.getElementById("copyOutput").value;
       try {
@@ -320,8 +361,10 @@ ${line("보안/운영/배포 관련 주의사항", state.opsSecurity)}
           ? { surface: "Application", workNature: "아직 모름", targetScope: "아직 모름", goalLevel: "아직 모름" }[key]
           : "";
       }
+      workspaceDirectoryHandle = null;
       document.querySelectorAll("[data-field]:not(.chip)").forEach((input) => { input.value = ""; });
       document.getElementById("copyStatus").textContent = "";
+      setWorkspacePickerStatus("", "hint");
       render();
     });
 

--- a/tests/test_github_pages_start_wizard.py
+++ b/tests/test_github_pages_start_wizard.py
@@ -110,6 +110,22 @@ def test_start_wizard_current_state_placeholder_uses_status_examples():
         assert state_example in current_state_placeholder
 
 
+def test_start_wizard_can_pick_workspace_directory_when_browser_supports_it():
+    html = read("docs/start/index.html")
+
+    assert 'id="chooseWorkspaceButton"' in html
+    assert 'id="workspacePickerStatus"' in html
+    assert "폴더 선택" in html
+    assert "window.showDirectoryPicker" in html
+    assert 'mode: "read"' in html
+    assert 'startIn: "documents"' in html
+    assert "workspaceDirectoryHandle" in html
+    assert "directoryHandle.name" in html
+    assert "폴더 선택을 지원하지 않는 브라우저" in html
+    assert "전체 로컬 경로 대신 선택한 폴더 이름" in html
+    assert "AbortError" in html
+
+
 def test_start_wizard_output_is_clone_ready_and_copyable():
     html = read("docs/start/index.html")
 


### PR DESCRIPTION
## change id

- chg-20260429-001

## 관련 issue

- EVNSolution/clever-change-control#42

## 대상 repo/service

- `clever-agent-project`
- GitHub Pages 시작 도우미 `docs/start/`

## 변경 내용

- `원하는 workspace 위치` 입력 옆에 `폴더 선택` 버튼을 추가했습니다.
- 지원 브라우저에서는 `window.showDirectoryPicker()`로 실제 폴더 선택 패널을 엽니다.
- 선택한 폴더 이름을 workspace 입력값과 copy text에 반영합니다.
- 브라우저가 전체 로컬 경로를 제공하지 않을 수 있으므로 폴더 이름 입력 + 직접 수정 fallback 안내를 표시합니다.
- 미지원 브라우저/취소/오류 상태를 status 문구로 안내합니다.

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: GitHub Pages 시작 도우미 workspace 입력 UX 개선
- same validation command: `python3 -m pytest -q`, Pages workflow validate job
- different app/service/contract surface: 없음
- merge order dependency: 없음
- rollback unit: `docs/start/index.html`, `tests/test_github_pages_start_wizard.py`

같은 issue 안의 같은 운영 문서/절차 정리이고 같은 검증으로 충분하면 `single-pr`로 둔다.
앱, 서비스, 계약 표면, merge 순서, 롤백 단위가 다르면 `split-required`로 둔다.

## 테스트 여부

- `python3 -m pytest -q` → 77 passed, 2 skipped
- `python3 -m compileall -q scripts tests .agent/skills/bootstrap-clever-work/scripts` → pass
- `node --check /tmp/clever-start-wizard.js` → pass
- `node /tmp/wizard-folder-picker-check.js` → pass
- local docs HTTP server root and `/start/` marker check → pass
- `git diff --check` → pass
- branch Pages validate run: https://github.com/EVNSolution/clever-agent-project/actions/runs/25084065586 → success

## 검수 포인트

- `폴더 선택` 버튼이 workspace 입력 근처에 보이는지
- 지원 브라우저에서 폴더 선택 패널이 열리는지
- 선택한 폴더 이름이 copy text의 `선호 workspace`에 들어가는지
- 미지원 브라우저에서는 직접 입력 안내가 보이는지

## rollout/rollback 영향

- rollout: main merge 후 GitHub Pages 시작 도우미에 폴더 선택 버튼이 표시됩니다.
- rollback: PR diff를 되돌리면 직접 입력만 남습니다.

## Concurrent Work Gate

- parallel work decision: `done`
- target repo issue: EVNSolution/clever-change-control#42
- clever-change-control issue: EVNSolution/clever-change-control#42
- open PR checked: none for this branch before PR creation
- conflict candidates: `docs/start/index.html`, `tests/test_github_pages_start_wizard.py`
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: MDN `Window.showDirectoryPicker()` docs via Context7
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: not-needed
- linked issue close evidence: merge 후 main Pages 검증 결과로 남김
