### PR TITLE
Preserve target repo handoff continuity after merge

### DIFF
--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -371,7 +371,8 @@ Once the user approves:
    - `docs/templates/target-repo-project-brief.md` -> target repo `docs/project-brief.md`
    - `docs/templates/apply-target-repo-rulesets.sh` -> target repo `scripts/apply-github-rulesets.sh`
    - `docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md` -> target repo `.github/PULL_REQUEST_TEMPLATE.md`
-7. Apply or confirm the branch operating contract in the target repo:
+7. 첫 main push 전에는 target repo 루트 `AGENTS.md`가 존재하고, copied source `docs/templates/target-repo-AGENTS.md`의 실행 절차가 반영되어 initial commit에 staged 되었는지 확인한다. 루트 `AGENTS.md`가 없거나 비어 있거나 staged 상태가 아니면 push하지 않는다. 먼저 stage한 뒤 `git status --short`와 `git diff --cached -- AGENTS.md`로 확인한다.
+8. Apply or confirm the branch operating contract in the target repo:
    - initial remote bootstrap commit may land on `main`
    - immediately after that, create and push `dev`
    - before applying rulesets or repository protection settings, run:
@@ -380,7 +381,7 @@ Once the user approves:
    - GitHub rulesets should target only `main` and `dev`: both require PR-only updates with `required_approving_review_count=0`, and other branches stay unrestricted by ruleset
    - after `dev` exists, block direct local pushes to `main`
    - default new work to task branches from `dev` unless the work is intentionally direct-on-`dev`
-8. Recommend a new session in the cloned target repo for planning or implementation.
+9. Recommend a new session in the cloned target repo for planning or implementation.
 
 Only after the root issue is approved and the execution scope is fixed should a scoped change request introduce a `change-id`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -592,6 +592,8 @@ When the agent bootstraps or confirms a target repo, it should preserve this mea
 - `dev = work`
 - `branch = role-specific work`
 
+첫 main push 전에는 target repo 루트 `AGENTS.md`가 `docs/templates/target-repo-AGENTS.md`에서 복사되어 initial commit에 포함되는지 반드시 확인한다. 누락, 빈 파일, stage 누락 상태이면 먼저 seed 파일을 복사/stage하고 `git status --short`, `git diff --cached -- AGENTS.md`로 확인하기 전에는 push하지 않는다.
+
 If local branch protection is requested or available, prefer a repo-local `pre-push` guard for `main`.
 
 ## PR Merge Commit Title Contract

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -355,6 +355,8 @@ PR 정보를 wiki에 올리는 것이 아니다. wiki에는 필요한 서비스/
 `AGENTS.md`는 프로젝트 설명서가 아니다. agent가 따라야 할 작업 순서, branch/issue 연결 방식, 테스트와 검증 순서, context 문서 반영 기준, 완료 조건을 담는다.
 또한 target repo에서 실행할 수 있는 branch role prefix 강제 hook 설치 명령을 포함한다.
 
+첫 main push 전에는 target repo 루트 `AGENTS.md`가 `docs/templates/target-repo-AGENTS.md`에서 복사되어 initial commit에 포함되는지 반드시 확인한다. 누락, 빈 파일, stage 누락 상태이면 먼저 seed 파일을 복사/stage하고 `git status --short`, `git diff --cached -- AGENTS.md`로 확인하기 전에는 push하지 않는다.
+
 `docs/project-brief.md`는 프로젝트 기획 초안이다. 목적, 기대 결과, 제약, 초기 범위, 미정 사항, 다음 작업 목록을 담는다.
 
 bootstrap packet의 `target_repo_seed_files` 항목은 위 두 파일을 target repo에 복사하라는 handoff 지시다. 확정되지 않은 placeholder는 추측해서 채우지 말고 `pending` 또는 빈 값으로 남긴다.

--- a/docs/templates/target-repo-AGENTS.md
+++ b/docs/templates/target-repo-AGENTS.md
@@ -80,6 +80,13 @@ preflight는 최소한 `gh auth status`, gh CLI에서 확인한 GitHub login 또
 초기 remote bootstrap 후에는 `dev`를 만들고, 이후 일반 작업은 `dev` 또는 task branch에서 진행한다.
 `dev`가 생긴 뒤에는 `main`에 직접 push하지 않는다.
 
+첫 main push 전 필수 확인:
+
+- target repo 루트 `AGENTS.md`가 존재해야 한다.
+- 루트 `AGENTS.md`는 bootstrap source `docs/templates/target-repo-AGENTS.md` 내용이 반영된 agent 실행 절차서여야 한다.
+- 위 항목이 빠졌거나 비어 있으면 첫 main push를 진행하지 않고, 먼저 seed 파일을 복사한 뒤 `git status --short`와 `git diff -- AGENTS.md`로 포함 여부를 확인한다.
+- 첫 main push commit에는 루트 `AGENTS.md`를 반드시 포함한다. 확인 전에는 push하지 않는다.
+
 ### PR merge commit 제목
 
 `main`으로 PR을 merge할 때는 GitHub 기본형 merge subject를 쓴다.
@@ -113,6 +120,26 @@ git fetch --prune origin
 - 기본은 `git branch -d <source-branch>`를 쓴다.
 - merge 없이 닫은 branch를 폐기해야 할 때만 사용자 확인 후 `git branch -D <source-branch>`를 쓴다.
 - remote branch가 GitHub에서 이미 삭제됐더라도 `git fetch --prune origin`으로 로컬 추적 branch를 정리한다.
+
+### 다음 작업 이슈 생성 템플릿
+
+main merge가 끝나고 관련 이슈/브랜치 정리까지 완료했으면 다음 작업을 시작하기 전에
+사용자에게 아래 이슈 생성 템플릿을 전달한다. 사용자가 작성한 템플릿이나 기존 issue URL을
+제공하기 전에는 새 구현 작업으로 넘어가지 않는다.
+
+```markdown
+[이슈 요약]:
+[이슈 내용]:
+[작업 유형]: [기능/버그/변경/리팩토링/문서/테스트/운영]
+[대상 범위]: [서비스/화면/API/문서/설정]
+[완료 기준]:
+- [ ]
+- [ ]
+[검증 방법]:
+- [ ]
+[참고 링크/자료]:
+- [ ]
+```
 
 ## GitHub Ruleset 운영
 

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -532,6 +532,41 @@ def test_docs_require_remote_task_branch_cleanup_after_pr_completion():
         assert "open PR" in text
 
 
+def test_target_repo_agents_prompts_next_issue_template_after_main_cleanup():
+    agents = (REPO_ROOT / "docs/templates/target-repo-AGENTS.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "### 다음 작업 이슈 생성 템플릿" in agents
+    assert "main merge" in agents
+    assert "이슈/브랜치 정리" in agents
+    assert "다음 작업을 시작하기 전에" in agents
+    assert "[이슈 요약]:" in agents
+    assert "[이슈 내용]:" in agents
+    assert "[완료 기준]:" in agents
+    assert "- [ ]" in agents
+    assert "사용자가 작성한 템플릿이나 기존 issue URL" in agents
+
+
+def test_first_main_push_requires_root_agents_seed_confirmation():
+    docs = [
+        (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8"),
+        (REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md").read_text(
+            encoding="utf-8"
+        ),
+        (REPO_ROOT / "docs/templates/target-repo-AGENTS.md").read_text(
+            encoding="utf-8"
+        ),
+        (REPO_ROOT / "docs/setting.md").read_text(encoding="utf-8"),
+    ]
+
+    for text in docs:
+        assert "첫 main push" in text
+        assert "루트 `AGENTS.md`" in text
+        assert "docs/templates/target-repo-AGENTS.md" in text
+        assert "push하지 않는다" in text
+
+
 def test_target_repo_pr_template_makes_review_finish_with_wiki_update():
     pr_template = (
         REPO_ROOT / "docs/templates/target-repo-PULL_REQUEST_TEMPLATE.md"


### PR DESCRIPTION
## Summary

- Require target repo bootstrap to confirm root `AGENTS.md` is staged before the first `main` push.
- Add the next-work issue creation template to injected target repo `AGENTS.md` for use after main merge and branch cleanup.
- Lock both rules with bootstrap documentation regression tests.

## Validation

- `python3 -m pytest -q` → 79 passed, 2 skipped
- `git diff --check`

## Context / wiki

- clever-context-monorepo update: not needed; this changes bootstrap execution guidance and seed template behavior in `clever-agent-project` only.
- linked issue close evidence: no separate target issue was provided for this maintenance request.
