### PR TITLE
Enforce issue-linked target workflow prompts

### DIFF
--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -69,6 +69,10 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo
 Interpret the result like this:
 
 - `preflight_check.ready=false`: stop and show the failed checks before asking startup questions.
+- Always read `workspace_check.session_open_check` before startup questions. The
+  Python preflight must confirm the CLEVER_ROOT-based session layout first:
+  three control-plane repos under `<CLEVER_ROOT>/clever-agent-workspace/`, target
+  repos under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`.
 - `preflight_check.ready=true`: continue by reading `workspace_check.agent_action`.
 - `auto_skipped_questions`: do not ask these questions again; tool evidence already answered them.
 - `recovery_actions`: use these concrete commands/actions to fix failed checks before continuing.

--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -26,6 +26,23 @@ The canonical identifier is the created `project-start` issue number in `clever-
 
 When a new target repo is created or bootstrapped, keep execution rules and planning content separate:
 
+Use this local folder layout unless the user has explicitly provided another path:
+
+```text
+<CLEVER_ROOT>/
+  clever-agent-project/
+  clever-context-monorepo/
+  clever-change-control/
+  projects/
+    <project-slug>/
+      <target-repo>/
+```
+
+The three agent/control-plane repositories stay directly under `<CLEVER_ROOT>`.
+Remote product/service repositories are cloned or pulled under
+`<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`. Seed files are copied
+into that target repo root.
+
 - `AGENTS.md`: agent execution procedure, working order, issue/branch rules, verification, context update checks, and completion conditions
 - `docs/project-brief.md`: project planning draft, purpose, constraints, scope, open questions, and next work list
 
@@ -365,7 +382,7 @@ Once the user approves:
    - 새 target repo는 public으로 생성한다.
    - Use `gh repo create <owner>/<repo> --public` for a newly created target repo.
    - GitHub Free organization rulesets are enforced on public repositories; private repository enforcement requires GitHub Team, GitHub Pro, or GitHub Enterprise Cloud.
-5. Clone or pull the target repo locally.
+5. Clone or pull the target repo under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`.
 6. Copy the target repo seed files before handoff:
    - `docs/templates/target-repo-AGENTS.md` -> target repo `AGENTS.md`
    - `docs/templates/target-repo-project-brief.md` -> target repo `docs/project-brief.md`

--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -30,15 +30,16 @@ Use this local folder layout unless the user has explicitly provided another pat
 
 ```text
 <CLEVER_ROOT>/
-  clever-agent-project/
-  clever-context-monorepo/
-  clever-change-control/
+  clever-agent-workspace/
+    clever-agent-project/
+    clever-context-monorepo/
+    clever-change-control/
   projects/
     <project-slug>/
       <target-repo>/
 ```
 
-The three agent/control-plane repositories stay directly under `<CLEVER_ROOT>`.
+The three agent/control-plane repositories stay under `<CLEVER_ROOT>/clever-agent-workspace/`.
 Remote product/service repositories are cloned or pulled under
 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`. Seed files are copied
 into that target repo root.

--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -383,6 +383,37 @@ Once the user approves:
    - default new work to task branches from `dev` unless the work is intentionally direct-on-`dev`
 9. Recommend a new session in the cloned target repo for planning or implementation.
 
+### Scoped Target Work After Bootstrap
+
+For every non-trivial development task after the target repo exists, the agent
+must treat the request as a GitHub issue-linked workflow before editing files:
+
+1. Create or identify the target repository issue.
+2. Create or identify the matching `clever-change-control` issue when scoped
+   change tracking is needed.
+3. Link both issues with explicit mentions.
+4. Create the branch only through GitHub Development:
+
+```bash
+gh issue develop <target-issue-number> \
+  --repo <target-repo-full-name> \
+  --base dev \
+  --name cc-<change-control-issue-number>-<short-scope> \
+  --checkout
+```
+
+5. Verify the linked branch:
+
+```bash
+gh issue develop --list <target-issue-number> \
+  --repo <target-repo-full-name>
+```
+
+Do not use `git checkout -b` first. Do not implement, commit, or open a PR until
+the issue link and GitHub Development linked branch are ready. PRs for normal
+work branch into `dev`, and PR bodies list the target issue plus the
+`clever-change-control` issue.
+
 Only after the root issue is approved and the execution scope is fixed should a scoped change request introduce a `change-id`.
 
 Do not create service-doc drafts in the normal start path.

--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -73,6 +73,9 @@ Interpret the result like this:
   Python preflight must confirm the CLEVER_ROOT-based session layout first:
   three control-plane repos under `<CLEVER_ROOT>/clever-agent-workspace/`, target
   repos under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`.
+- Always read `preflight_check.agent_response_contract` before replying to a
+  CLEVER_ROOT-level prompt. It defines the response style: inherit the CLEVER
+  agent workflow, complete initial setup, then continue with the provided prompt.
 - `preflight_check.ready=true`: continue by reading `workspace_check.agent_action`.
 - `auto_skipped_questions`: do not ask these questions again; tool evidence already answered them.
 - `recovery_actions`: use these concrete commands/actions to fix failed checks before continuing.

--- a/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
+++ b/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
@@ -738,6 +738,56 @@ def build_preflight_next_questions(
     return questions
 
 
+def build_agent_response_contract(workspace_check: dict[str, Any]) -> dict[str, Any]:
+    agent_action = workspace_check.get("agent_action")
+    session_open_check = workspace_check.get("session_open_check") or {}
+    initial_steps = [
+        "do not start implementation directly from a free-form prompt",
+        "inherit the CLEVER agent-based workflow from clever-agent-project",
+        "confirm the CLEVER_ROOT session layout with workspace_check.session_open_check",
+        "create or confirm the target repository only after the project-start gate",
+        "apply or confirm repository rules before normal development",
+        "clone or pull the target repo under <CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+        "inject AGENTS.md, docs/project-brief.md, PR template, and ruleset script into the target repo root",
+        "after initial setup succeeds, continue according to the user's provided prompt",
+    ]
+    if agent_action == "switch-to-clever-agent-project":
+        immediate_reply = (
+            "현재 세션은 CLEVER_ROOT 또는 control-plane 시작 위치로 감지했습니다. "
+            "바로 작업을 시작하지 않고 `clever-agent-workspace/clever-agent-project`의 "
+            "에이전트 기반 절차를 먼저 전수받아 preflight와 초기 세팅을 진행하겠습니다."
+        )
+    elif agent_action == "proceed-with-hard-gate":
+        immediate_reply = (
+            "에이전트 기반 preflight가 통과했습니다. 바로 구현하지 않고 작업 시작 정보를 "
+            "정규화한 뒤 project-start, repo bootstrap, 규칙 적용, pull/clone, 에이전트 문서 "
+            "주입 순서로 진행하겠습니다."
+        )
+    elif agent_action == "current-repo-maintenance":
+        immediate_reply = (
+            "현재 작업은 control-plane repo maintenance로 감지했습니다. 해당 repo 범위에서만 "
+            "에이전트 절차를 적용하고 일반 target repo bootstrap으로 내려가지 않겠습니다."
+        )
+    else:
+        immediate_reply = (
+            "CLEVER_ROOT 기반 세션 검증이 아직 완료되지 않았습니다. 작업을 시작하지 않고 "
+            "누락된 agent workspace와 3대 레포 구성을 먼저 복구하겠습니다."
+        )
+
+    return {
+        "do_not_start_freeform_work": True,
+        "session_open_status": session_open_check.get("status"),
+        "agent_action": agent_action,
+        "initial_steps": initial_steps,
+        "immediate_reply_style": immediate_reply,
+        "after_initial_setup_success_reply_style": (
+            "초기 작업(레포 확인/생성, repo 규칙 생성 또는 확인, pull/clone, "
+            "에이전트 문서 주입)이 완료됐습니다. 다음 작업은 주신 프롬프트대로 "
+            "<normalized-next-work>를 진행하겠습니다."
+        ),
+    }
+
+
 def build_preflight_check(
     *,
     cwd: Path,
@@ -1090,6 +1140,7 @@ def build_preflight_check(
         workspace_check=workspace_check,
         github_login=github_login,
     )
+    agent_response_contract = build_agent_response_contract(workspace_check)
     return {
         "mode": mode,
         "ready": ready,
@@ -1102,6 +1153,7 @@ def build_preflight_check(
         "auto_skipped_questions": auto_skipped_questions,
         "recovery_actions": recovery_actions,
         "next_questions": next_questions,
+        "agent_response_contract": agent_response_contract,
     }
 
 

--- a/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
+++ b/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
@@ -1346,10 +1346,21 @@ def build_packet(
             "visibility_reason": visibility_reason,
             "status": "proposed-after-approval",
             "proposal": repo_bootstrap_proposal,
+            "local_folder_layout": {
+                "control_plane_root": "<CLEVER_ROOT>",
+                "control_plane_repositories": [
+                    "clever-agent-project",
+                    "clever-context-monorepo",
+                    "clever-change-control",
+                ],
+                "project_repositories_root": "<CLEVER_ROOT>/projects/<project-slug>",
+                "target_repo_checkout": "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+                "seed_injection_root": "target repo root",
+            },
             "post_create_clone": [
                 "create-or-confirm public target repo after project-start approval",
-                "clone-or-pull the target repo locally",
-                "copy target repo seed files before handoff",
+                "clone-or-pull the target repo under <CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+                "copy target repo seed files into the target repo root before handoff",
                 "apply GitHub rulesets after dev exists",
                 "verify local checkout is ready for follow-on work",
             ],
@@ -1362,7 +1373,7 @@ def build_packet(
         },
         "next_step": (
             "Present the project-start draft for approval. After approval, create the issue, "
-            "propose repo bootstrap, clone or pull the target repo, seed the target repo, "
+            "propose repo bootstrap, clone or pull the target repo under the projects folder, seed the target repo, "
             "and recommend a new target-repo session."
         ),
     }

--- a/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
+++ b/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
@@ -15,6 +15,8 @@ from typing import Any, Iterable
 
 CONTEXT_REPO_NAME = "clever-context-monorepo"
 CHANGE_REPO_NAME = "clever-change-control"
+AGENT_WORKSPACE_DIR_NAME = "clever-agent-workspace"
+PROJECTS_DIR_NAME = "projects"
 START_REPO_NAME = "clever-agent-project"
 CONTROL_PLANE_REPOS = (
     START_REPO_NAME,
@@ -245,6 +247,16 @@ def is_checkout_root(path: Path) -> bool:
 
 
 def infer_workspace_root(start: Path, git_root: Path | None = None) -> Path:
+    """Return the control-plane root that contains the three agent repos.
+
+    Preferred layout:
+
+        <CLEVER_ROOT>/clever-agent-workspace/{three control-plane repos}
+        <CLEVER_ROOT>/projects/<project-slug>/<target-repo>
+
+    Legacy direct layout is still recognized so existing local checkouts can report
+    a useful migration-oriented preflight instead of failing path discovery.
+    """
     seen: set[Path] = set()
     candidates: list[Path] = list(iter_ancestors(start))
     if git_root is not None:
@@ -255,12 +267,69 @@ def infer_workspace_root(start: Path, git_root: Path | None = None) -> Path:
         if resolved in seen:
             continue
         seen.add(resolved)
+
+        nested_control_root = resolved / AGENT_WORKSPACE_DIR_NAME
+        if any((nested_control_root / repo_name_value).exists() for repo_name_value in CONTROL_PLANE_REPOS):
+            return nested_control_root.resolve()
+
         if any((resolved / repo_name_value).exists() for repo_name_value in CONTROL_PLANE_REPOS):
             return resolved
 
     if git_root is not None:
         return git_root.parent.resolve()
     return start.resolve()
+
+
+def derive_clever_work_root(control_plane_root: Path) -> Path:
+    if control_plane_root.name == AGENT_WORKSPACE_DIR_NAME:
+        return control_plane_root.parent.resolve()
+    return control_plane_root.resolve()
+
+
+def is_relative_to_path(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def build_session_open_check(*, cwd: Path, control_plane_root: Path, current_repo: str | None) -> dict[str, Any]:
+    clever_work_root = derive_clever_work_root(control_plane_root)
+    expected_control_plane_root = clever_work_root / AGENT_WORKSPACE_DIR_NAME
+    projects_root = clever_work_root / PROJECTS_DIR_NAME
+    uses_expected_nested_layout = control_plane_root.resolve() == expected_control_plane_root.resolve()
+    cwd_under_control_plane = is_relative_to_path(cwd, control_plane_root)
+    cwd_under_projects = is_relative_to_path(cwd, projects_root)
+    opened_from_start_repo = current_repo == START_REPO_NAME and cwd_under_control_plane
+    opened_from_control_plane_repo = current_repo in CONTROL_PLANE_REPOS and cwd_under_control_plane
+
+    if uses_expected_nested_layout:
+        status = "pass" if (opened_from_control_plane_repo or cwd_under_projects) else "fail"
+        layout_mode = "clever-root-with-agent-workspace"
+    else:
+        status = "legacy-layout" if opened_from_control_plane_repo else "fail"
+        layout_mode = "legacy-direct-control-plane-root"
+
+    return {
+        "status": status,
+        "layout_mode": layout_mode,
+        "clever_root": str(clever_work_root),
+        "control_plane_root": str(control_plane_root),
+        "expected_control_plane_root": str(expected_control_plane_root),
+        "projects_root": str(projects_root),
+        "cwd_under_control_plane_root": cwd_under_control_plane,
+        "cwd_under_projects_root": cwd_under_projects,
+        "opened_from_start_repo": opened_from_start_repo,
+        "opened_from_control_plane_repo": opened_from_control_plane_repo,
+        "message": (
+            "Session path matches the CLEVER_ROOT layout."
+            if status == "pass"
+            else "Session uses the legacy direct control-plane layout; prefer <CLEVER_ROOT>/clever-agent-workspace for the three agent repos."
+            if status == "legacy-layout"
+            else "Session is not opened from the expected CLEVER_ROOT control-plane or projects layout."
+        ),
+    }
 
 
 def probe_repo_checkout(
@@ -291,6 +360,11 @@ def build_workspace_check(start: Path, *, current_repo_maintenance: bool = False
     branch_name = current_branch(git_root) if git_root else None
     preferred_checkout_name = git_root.name if git_root else None
     clever_root = infer_workspace_root(cwd, git_root)
+    session_open_check = build_session_open_check(
+        cwd=cwd,
+        control_plane_root=clever_root,
+        current_repo=current_repo,
+    )
 
     repos: dict[str, dict[str, Any]] = {}
     missing_repositories: list[str] = []
@@ -351,6 +425,10 @@ def build_workspace_check(start: Path, *, current_repo_maintenance: bool = False
         "current_repo": current_repo,
         "current_branch": branch_name,
         "clever_root": str(clever_root),
+        "clever_work_root": session_open_check["clever_root"],
+        "control_plane_root": session_open_check["control_plane_root"],
+        "projects_root": session_open_check["projects_root"],
+        "session_open_check": session_open_check,
         "control_plane_complete": control_plane_complete,
         "current_repo_is_start": current_repo_is_start,
         "current_repo_maintenance_requested": current_repo_maintenance,
@@ -1474,6 +1552,12 @@ def print_workspace_check(workspace_check: dict[str, Any]) -> None:
     print(f"git-root: {workspace_check['git_root']}")
     print(f"current-repo: {workspace_check['current_repo']}")
     print(f"clever-root: {workspace_check['clever_root']}")
+    print(f"clever-work-root: {workspace_check['clever_work_root']}")
+    print(f"control-plane-root: {workspace_check['control_plane_root']}")
+    print(f"projects-root: {workspace_check['projects_root']}")
+    session_open_check = workspace_check.get("session_open_check", {})
+    print(f"session-open-check: {session_open_check.get('status')}")
+    print(f"session-open-message: {session_open_check.get('message')}")
     print(
         "control-plane-complete: "
         f"{'yes' if workspace_check['control_plane_complete'] else 'no'}"

--- a/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
+++ b/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
@@ -1347,7 +1347,7 @@ def build_packet(
             "status": "proposed-after-approval",
             "proposal": repo_bootstrap_proposal,
             "local_folder_layout": {
-                "control_plane_root": "<CLEVER_ROOT>",
+                "control_plane_root": "<CLEVER_ROOT>/clever-agent-workspace",
                 "control_plane_repositories": [
                     "clever-agent-project",
                     "clever-context-monorepo",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,10 +428,11 @@ Short version:
 - anchor and trace in `clever-change-control`
 - implement in the target repository
 
-## Target Repository Traceability Gate
+## Target Repository GitHub Workflow Gate
 
-This gate applies to every target project opened with this three-repository control
-plane, regardless of the directory where the agent session starts.
+This gate applies to every non-trivial development task in a target repository.
+It exists so the agent interprets implementation requests as a GitHub
+issue-linked workflow, not as an immediate local edit.
 
 Do not treat GitHub automatic references as sufficient traceability. Plain issue
 mentions such as `<context-owner>/<root-context-repo>#<issue>` or
@@ -442,37 +443,110 @@ Do not hard-code a GitHub organization, root context repository, or target
 repository name in this rule. Resolve repository identifiers from the current
 workspace, `git remote -v`, issue URLs, or explicit user instructions.
 
-Before any target-repository implementation, the agent must establish an
-issue-to-branch trace chain anchored in `clever-change-control`.
+Before any implementation, commit, or PR in a target repository, complete this
+sequence in order:
 
-Required chain:
+1. Create or identify the target repository issue for the actual work.
+2. When the work needs scoped change tracking, create or identify the matching
+   `clever-change-control` issue.
+3. Link the target issue and the `clever-change-control` issue to each other
+   with explicit issue mentions.
+4. Create the work branch from the target issue with GitHub Development. Do not
+   run `git checkout -b` first.
+5. Verify the linked branch after creation.
+6. Only after the target issue, optional change-control issue, and linked branch
+   are ready may the agent implement, commit, or open a PR.
 
-1. Identify the root context issue when one exists, such as
-   `<context-owner>/<root-context-repo>#<issue>`.
-2. Identify or create the `clever-change-control` anchor:
-   - `project-start` issue for the root start record
-   - `change-request` issue for scoped execution
-3. Identify or create the target repository issue for the actual work, such as
-   `<target-owner>/<target-repo>#<issue>`.
-4. Cross-link the records with explicit issue mentions:
-   - the `clever-change-control` issue mentions the root context issue and target
-     repository issue
-   - the target repository issue mentions the `clever-change-control` issue
-5. Create or confirm a branch for the scoped work before implementation.
+CLI branch creation must use this shape, with the actual target repo resolved
+from the task context:
 
-Branch rules:
+```bash
+gh issue develop <target-issue-number> \
+  --repo <target-repo-full-name> \
+  --base dev \
+  --name cc-<change-control-issue-number>-<short-scope> \
+  --checkout
+```
 
-- A branch must correspond to a tracked issue or scoped work item.
-- One parent issue may have many child branches.
-- Prefer branch names that include the trace identifier, for example:
-  - `cc-12-issue-34-login-timeout`
-  - `issue-34-login-timeout`
-- If multiple branches belong to one issue, list all active branches on the
-  `clever-change-control` issue.
+Then verify the GitHub Development linked branch:
 
-The agent must not begin implementation if the trace chain is missing. First
-create or identify the required issue records, add the bidirectional mentions,
-and state the branch that will carry the work.
+```bash
+gh issue develop --list <target-issue-number> \
+  --repo <target-repo-full-name>
+```
+
+For a task explicitly targeting `EVNSolution/thundercrew-domain`, the command
+uses `--repo EVNSolution/thundercrew-domain` and `--base dev`.
+
+Branch and PR rules:
+
+- Work branches always start from `dev`.
+- The branch name format is exactly
+  `cc-<change-control-issue-number>-<short-scope>`, for example
+  `cc-74-dashboard-mapstate-frontend`.
+- If a change-control issue is genuinely not needed, create a target issue first
+  and record why no `clever-change-control` issue is needed before choosing a
+  branch name.
+- PRs for non-trivial development go from the work branch into `dev`.
+- The PR body must list both the target issue and the `clever-change-control`
+  issue, or explicitly state why no change-control issue was needed.
+
+Forbidden actions:
+
+- Do not create the work branch manually with `git checkout -b` before GitHub
+  Development links it to the target issue.
+- Do not work on a branch that is not linked to a GitHub issue through
+  `gh issue develop`.
+- Do not develop or commit directly on `dev`.
+- Do not create a branch without an issue.
+- Do not implement without a linked branch.
+- Do not merge into `dev` without a PR.
+- Do not expose internal agent/tool names in public commit titles, PR titles,
+  merge commit titles, or GitHub attribution unless they are directly relevant.
+- Do not leave internal automation attribution such as `Co-authored-by: OmX` in
+  public development history.
+
+Merge rules:
+
+- Prefer a merge method where the PR trace is visible in `dev` history, such as
+  a merge commit.
+- If squash merge is necessary, the squash commit title must include the PR
+  number, for example `Dashboard map-state frontend integration (#62)`.
+- Do not create PR-numberless squash commits, commit titles that look like direct
+  commits to `dev`, or merge commits with unclear provenance.
+
+Minimum verification before opening the PR:
+
+```bash
+npm run check:workspace
+npm run lint
+npm run typecheck
+npm run build
+```
+
+If frontend tests exist, also run:
+
+```bash
+npm run test:service-ops
+# plus the relevant frontend test command
+```
+
+If backend code changed, also run:
+
+```bash
+cd development/service-ops-api && ./gradlew test
+cd development/service-ops-api && ./gradlew build
+```
+
+Every work report must include:
+
+1. target issue number
+2. change-control issue number, or the recorded reason it was not needed
+3. linked branch name
+4. PR number
+5. merge commit
+6. verification command results
+7. remaining follow-up work
 
 ## Concurrent Work Gate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,18 @@ The preflight must verify at least:
 - remote fetch access
 - GitHub repo visibility and issue/PR/ruleset read access
 
+If the session is opened from `<CLEVER_ROOT>` itself, do not improvise a new
+workflow and do not start implementation. First hand the session into the
+agent-based path under `clever-agent-workspace/clever-agent-project`, run the
+Python preflight, and read `preflight_check.agent_response_contract`. The first
+answer should say that the agent will inherit the CLEVER workflow, complete
+initial setup (repo confirmation/creation, repo rules, pull/clone, agent document
+injection), and only then continue with the user's prompt.
+
+After initial setup succeeds, answer in this style:
+
+> 초기 작업(레포 확인/생성, repo 규칙 생성 또는 확인, pull/clone, 에이전트 문서 주입)이 완료됐습니다. 다음 작업은 주신 프롬프트대로 `<normalized-next-work>`를 진행하겠습니다.
+
 If `preflight_check.ready` is false, stop before startup questions and report the
 failed checks.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,16 +19,17 @@ Recommended local layout:
 
 ```text
 <CLEVER_ROOT>/
-  clever-agent-project/
-  clever-context-monorepo/
-  clever-change-control/
+  clever-agent-workspace/
+    clever-agent-project/
+    clever-context-monorepo/
+    clever-change-control/
   projects/
     <project-slug>/
       <target-repo>/
 ```
 
-`<CLEVER_ROOT>` is the control-plane root. Keep only the three agent/control
-repositories as first-class siblings there. Put real product/service target
+`<CLEVER_ROOT>` is the top-level CLEVER work root. Keep the three agent/control
+repositories inside `<CLEVER_ROOT>/clever-agent-workspace/`. Put real product/service target
 repositories under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`. When
 bootstrapping a target repo, clone or pull the remote repo into that project
 folder, then inject the agent documents into the target repo root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,24 @@ Before doing any real work, confirm that all of the following repositories exist
 2. `clever-context-monorepo`
 3. `clever-change-control`
 
+Recommended local layout:
+
+```text
+<CLEVER_ROOT>/
+  clever-agent-project/
+  clever-context-monorepo/
+  clever-change-control/
+  projects/
+    <project-slug>/
+      <target-repo>/
+```
+
+`<CLEVER_ROOT>` is the control-plane root. Keep only the three agent/control
+repositories as first-class siblings there. Put real product/service target
+repositories under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`. When
+bootstrapping a target repo, clone or pull the remote repo into that project
+folder, then inject the agent documents into the target repo root.
+
 If any of these repositories are missing, the workspace is incomplete.
 Do not pretend web links are a substitute for local context.
 Stop and state that the three-repository local workspace is required.
@@ -740,7 +758,7 @@ The expected operating flow is:
 5. Anchor the root line in `clever-change-control`
 6. Fix scoped execution
 7. Apply or confirm the repo branch operating contract
-8. Handoff to the target repository
+8. Handoff to the target repository under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`
 9. Feed rollout / rollback / release evidence back into `clever-change-control`
 
 ## If The Workspace Is Incomplete

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,13 @@ failed checks.
 
 Read these preflight output fields before asking anything:
 
+- `workspace_check.session_open_check`: the Python preflight's CLEVER_ROOT-based
+  session-open validation. It must confirm the expected structure
+  `<CLEVER_ROOT>/clever-agent-workspace/{three control-plane repos}` and
+  `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>` before startup work
+  proceeds. If it reports `legacy-layout`, treat it as a migration warning and
+  keep the target project checkout under `<CLEVER_ROOT>/projects/`. If it
+  reports `fail`, stop and fix the session location first.
 - `auto_skipped_questions`: questions already answered by tool evidence, such as
   GitHub login inference, startup location, or dirty-state inspection.
 - `recovery_actions`: concrete commands or actions for failed checks.

--- a/README.md
+++ b/README.md
@@ -38,41 +38,31 @@ CLEVER는 한 가지 앱 전용 흐름이 아니다. 사용자가 익숙한 도�
 
 브라우저에서 버튼과 텍스트 입력으로 한 번에 정리하려면 [GitHub Pages 시작 도우미](https://evnsolution.github.io/clever-agent-project/start/)를 사용한다. 버튼과 텍스트 입력으로 답한 뒤 최종 copy text를 만들고, 에이전트에 붙여 넣을 위치까지 안내한다.
 
-### `<CLEVER_ROOT>`에서 에이전트에게 바로 붙여 넣는 프롬프트
+### 새 폴더에서 에이전트에게 바로 붙여 넣는 프롬프트
 
-이미 `<CLEVER_ROOT>`를 열어 둔 상태에서 에이전트에게 시작을 맡기려면 아래 프롬프트를 그대로 붙여 넣는다. 이 프롬프트는 에이전트가 바로 구현을 시작하지 않고, 먼저 `clever-agent-workspace/clever-agent-project`의 에이전트 기반 절차를 전수받아 초기 작업을 끝낸 뒤 다음 작업으로 넘어가게 만든다.
+아직 로컬 구조가 없거나, 새 CLEVER 작업 루트에서 시작하려면 아래처럼 짧게 지시한다. 에이전트는 먼저 폴더를 만들고 3대 레포를 받은 뒤, `clever-agent-project`의 지침에 따라 작업 준비를 끝내야 한다.
 
 ```text
-지금 위치를 <CLEVER_ROOT>로 보고 CLEVER 작업을 시작해줘.
+새 CLEVER 작업 루트를 하나 만들고 시작해줘.
 
-중요: 이 프롬프트를 받았다고 바로 구현하거나 임의로 repo를 수정하지 마.
-먼저 <CLEVER_ROOT>/clever-agent-workspace/clever-agent-project 의 에이전트 기반 절차를 기준으로 삼아줘.
+1. 현재 위치 아래에 <CLEVER_ROOT> 폴더를 하나 만들거나, 이미 적절한 작업 루트가 있으면 그곳을 사용해줘.
+2. <CLEVER_ROOT>/clever-agent-workspace/ 폴더를 만들고 그 안에 아래 3대 레포를 clone 또는 pull 해줘.
+   - https://github.com/EVNSolution/clever-agent-project.git
+   - https://github.com/EVNSolution/clever-context-monorepo.git
+   - https://github.com/EVNSolution/clever-change-control.git
+3. 이후 작업 기준은 <CLEVER_ROOT>/clever-agent-workspace/clever-agent-project 로 잡아줘.
+4. clever-agent-project의 README와 AGENTS.md 지침을 읽고, 그 지침에 따라 preflight와 작업 준비를 진행해줘.
+5. 실제 제품/서비스 target repo는 <CLEVER_ROOT>/projects/<project-slug>/<target-repo>/ 아래에 준비해줘.
+6. target repo를 만들거나 확인한 뒤에는 clever-agent-project 지침에 따라 agent 문서를 target repo에 주입해줘.
+7. 초기 준비가 끝나기 전에는 구현, 커밋, PR 생성을 시작하지 마.
+8. 초기 준비가 성공하면 아래 형식으로 답해줘.
 
-해야 할 초기 작업:
-1. <CLEVER_ROOT>/clever-agent-workspace/ 아래에 3대 레포가 있는지 확인해줘.
-   - clever-agent-project
-   - clever-context-monorepo
-   - clever-change-control
-2. 없거나 불완전한 repo만 EVNSolution GitHub에서 clone 또는 pull 해줘.
-3. clever-agent-project 로 이동해서 Python preflight를 실행해줘.
-   python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
-4. preflight_check.workspace_check.session_open_check 와 preflight_check.agent_response_contract 를 먼저 읽어줘.
-5. preflight가 실패하면 바로 작업 질문으로 넘어가지 말고, 부족한 항목과 복구 작업을 먼저 보고해줘.
-6. preflight가 통과하면 target repo를 확인하거나 생성할 준비를 해줘.
-7. target repo는 <CLEVER_ROOT>/projects/<project-slug>/<target-repo>/ 아래에 clone 또는 pull 해줘.
-8. target repo 루트에 에이전트 문서를 주입해줘.
-   - AGENTS.md
-   - docs/project-brief.md
-   - .github/PULL_REQUEST_TEMPLATE.md
-   - scripts/apply-github-rulesets.sh
-9. repo 규칙, dev branch, ruleset 적용 또는 확인이 필요한 단계는 에이전트 절차대로 진행해줘.
-10. 초기 작업이 성공하면 아래 형식으로 답해줘.
-
-초기 작업(레포 확인/생성, repo 규칙 생성 또는 확인, pull/clone, 에이전트 문서 주입)이 완료됐습니다. 다음 작업은 주신 프롬프트대로 <내가 요청한 작업 요약>을 진행하겠습니다.
+초기 작업(작업 루트 생성, 3대 레포 준비, preflight, target repo 준비, 에이전트 문서 주입)이 완료됐습니다. 다음 작업은 주신 프롬프트대로 <내가 요청한 작업 요약>을 진행하겠습니다.
 
 내가 요청한 실제 작업은 다음 메시지 또는 아래 내용이야:
 - 작업 내용: <여기에 원하는 작업을 적는다>
 ```
+
 
 <details>
 <summary><strong>앱형 에이전트 / Application</strong> — 채팅에 프롬프트를 붙여 넣고 기본 세팅을 맡긴다.</summary>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ CLEVER는 한 가지 앱 전용 흐름이 아니다. 사용자가 익숙한 도�
 첫 화면에서는 직접 shell 명령보다 **어떤 환경에서 시작하는지**를 먼저 고른다.
 공통 원칙은 **3개 레포를 같은 로컬 workspace에 두고, 일반 시작은 `clever-agent-project`에서 진행한다**는 점이다.
 
+권장 폴더 구조는 아래처럼 나눈다. `<CLEVER_ROOT>`는 에이전트 제어 평면이고, 실제 제품/서비스 코드는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/` 아래에 둔다. target repo를 만들거나 확인한 뒤에는 이 프로젝트 폴더에 원격 repo를 clone/pull 하고, 그 repo 루트에 `AGENTS.md`, `docs/project-brief.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `scripts/apply-github-rulesets.sh`를 주입한다.
+
+```text
+<CLEVER_ROOT>/
+  clever-agent-project/
+  clever-context-monorepo/
+  clever-change-control/
+  projects/
+    <project-slug>/
+      <target-repo>/
+        AGENTS.md
+        docs/project-brief.md
+        .github/PULL_REQUEST_TEMPLATE.md
+        scripts/apply-github-rulesets.sh
+```
+
 브라우저에서 버튼과 텍스트 입력으로 한 번에 정리하려면 [GitHub Pages 시작 도우미](https://evnsolution.github.io/clever-agent-project/start/)를 사용한다. 버튼과 텍스트 입력으로 답한 뒤 최종 copy text를 만들고, 에이전트에 붙여 넣을 위치까지 안내한다.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -38,6 +38,42 @@ CLEVER는 한 가지 앱 전용 흐름이 아니다. 사용자가 익숙한 도�
 
 브라우저에서 버튼과 텍스트 입력으로 한 번에 정리하려면 [GitHub Pages 시작 도우미](https://evnsolution.github.io/clever-agent-project/start/)를 사용한다. 버튼과 텍스트 입력으로 답한 뒤 최종 copy text를 만들고, 에이전트에 붙여 넣을 위치까지 안내한다.
 
+### `<CLEVER_ROOT>`에서 에이전트에게 바로 붙여 넣는 프롬프트
+
+이미 `<CLEVER_ROOT>`를 열어 둔 상태에서 에이전트에게 시작을 맡기려면 아래 프롬프트를 그대로 붙여 넣는다. 이 프롬프트는 에이전트가 바로 구현을 시작하지 않고, 먼저 `clever-agent-workspace/clever-agent-project`의 에이전트 기반 절차를 전수받아 초기 작업을 끝낸 뒤 다음 작업으로 넘어가게 만든다.
+
+```text
+지금 위치를 <CLEVER_ROOT>로 보고 CLEVER 작업을 시작해줘.
+
+중요: 이 프롬프트를 받았다고 바로 구현하거나 임의로 repo를 수정하지 마.
+먼저 <CLEVER_ROOT>/clever-agent-workspace/clever-agent-project 의 에이전트 기반 절차를 기준으로 삼아줘.
+
+해야 할 초기 작업:
+1. <CLEVER_ROOT>/clever-agent-workspace/ 아래에 3대 레포가 있는지 확인해줘.
+   - clever-agent-project
+   - clever-context-monorepo
+   - clever-change-control
+2. 없거나 불완전한 repo만 EVNSolution GitHub에서 clone 또는 pull 해줘.
+3. clever-agent-project 로 이동해서 Python preflight를 실행해줘.
+   python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
+4. preflight_check.workspace_check.session_open_check 와 preflight_check.agent_response_contract 를 먼저 읽어줘.
+5. preflight가 실패하면 바로 작업 질문으로 넘어가지 말고, 부족한 항목과 복구 작업을 먼저 보고해줘.
+6. preflight가 통과하면 target repo를 확인하거나 생성할 준비를 해줘.
+7. target repo는 <CLEVER_ROOT>/projects/<project-slug>/<target-repo>/ 아래에 clone 또는 pull 해줘.
+8. target repo 루트에 에이전트 문서를 주입해줘.
+   - AGENTS.md
+   - docs/project-brief.md
+   - .github/PULL_REQUEST_TEMPLATE.md
+   - scripts/apply-github-rulesets.sh
+9. repo 규칙, dev branch, ruleset 적용 또는 확인이 필요한 단계는 에이전트 절차대로 진행해줘.
+10. 초기 작업이 성공하면 아래 형식으로 답해줘.
+
+초기 작업(레포 확인/생성, repo 규칙 생성 또는 확인, pull/clone, 에이전트 문서 주입)이 완료됐습니다. 다음 작업은 주신 프롬프트대로 <내가 요청한 작업 요약>을 진행하겠습니다.
+
+내가 요청한 실제 작업은 다음 메시지 또는 아래 내용이야:
+- 작업 내용: <여기에 원하는 작업을 적는다>
+```
+
 <details>
 <summary><strong>앱형 에이전트 / Application</strong> — 채팅에 프롬프트를 붙여 넣고 기본 세팅을 맡긴다.</summary>
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ CLEVER는 한 가지 앱 전용 흐름이 아니다. 사용자가 익숙한 도�
 첫 화면에서는 직접 shell 명령보다 **어떤 환경에서 시작하는지**를 먼저 고른다.
 공통 원칙은 **3개 레포를 같은 로컬 workspace에 두고, 일반 시작은 `clever-agent-project`에서 진행한다**는 점이다.
 
-권장 폴더 구조는 아래처럼 나눈다. `<CLEVER_ROOT>`는 에이전트 제어 평면이고, 실제 제품/서비스 코드는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/` 아래에 둔다. target repo를 만들거나 확인한 뒤에는 이 프로젝트 폴더에 원격 repo를 clone/pull 하고, 그 repo 루트에 `AGENTS.md`, `docs/project-brief.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `scripts/apply-github-rulesets.sh`를 주입한다.
+권장 폴더 구조는 아래처럼 나눈다. `<CLEVER_ROOT>`는 전체 CLEVER 작업 루트이고, 에이전트 제어 평면은 `<CLEVER_ROOT>/clever-agent-workspace/`이며, 실제 제품/서비스 코드는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/` 아래에 둔다. target repo를 만들거나 확인한 뒤에는 이 프로젝트 폴더에 원격 repo를 clone/pull 하고, 그 repo 루트에 `AGENTS.md`, `docs/project-brief.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `scripts/apply-github-rulesets.sh`를 주입한다.
 
 ```text
 <CLEVER_ROOT>/
-  clever-agent-project/
-  clever-context-monorepo/
-  clever-change-control/
+  clever-agent-workspace/
+    clever-agent-project/
+    clever-context-monorepo/
+    clever-change-control/
   projects/
     <project-slug>/
       <target-repo>/

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -145,19 +145,20 @@ CLEVER 관련 저장소는 하나의 workspace root 아래에 두는 것을 권�
 
 ```text
 <CLEVER_ROOT>/
-  clever-agent-project/
-  clever-change-control/
-  clever-context-monorepo/
+  clever-agent-workspace/
+    clever-agent-project/
+    clever-change-control/
+    clever-context-monorepo/
   projects/
     <project-slug>/
       <target-repo>/
 ```
 
-`<CLEVER_ROOT>`는 에이전트 제어 평면이다. 3대 레포는 항상 이 루트의 sibling으로 둔다.
+`<CLEVER_ROOT>`는 전체 CLEVER 작업 루트다. 에이전트 제어 평면은 `<CLEVER_ROOT>/clever-agent-workspace/`이고, 3대 레포는 항상 그 안의 sibling으로 둔다.
 실제 제품/서비스 원격 repo는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`
 아래에 clone 또는 pull 한다. 새 target repo seed 파일은 이 target repo 루트에 주입한다.
 
-generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-project`에서 시작한다. 승인 후 target GitHub repo를 생성하거나 확인한 다음, `<CLEVER_ROOT>/projects/<project-slug>/` 아래에 로컬 clone 또는 pull 하고 그 target repo 루트에서 새 세션을 시작한다.
+generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-workspace/clever-agent-project`에서 시작한다. 승인 후 target GitHub repo를 생성하거나 확인한 다음, `<CLEVER_ROOT>/projects/<project-slug>/` 아래에 로컬 clone 또는 pull 하고 그 target repo 루트에서 새 세션을 시작한다.
 
 예외는 sibling control-plane repo 자체를 직접 수정하는 경우다.
 

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -387,6 +387,12 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo
 이때 `recovery_actions`에 실패 check별 복구 명령이나 처리 지시가 들어간다.
 `auto_skipped_questions`는 도구가 이미 답한 질문이므로 다시 묻지 않는다.
 `next_questions`는 자동 확인 뒤에도 남아 있는 최소 사용자 질문만 담는다.
+`preflight_check.agent_response_contract`는 `<CLEVER_ROOT>`에서 프롬프트를 받았을 때
+에이전트가 어떻게 첫 답변을 해야 하는지 고정한다. 바로 구현하지 말고
+에이전트 기반 절차를 전수받아 preflight, repo 확인/생성, ruleset 확인/생성,
+pull/clone, target repo agent 문서 주입을 먼저 끝낸 뒤 "초기 작업이 완료됐고,
+다음 작업은 주신 프롬프트대로 진행하겠다"는 형태로 답한다.
+
 `workspace_check.session_open_check`는 Python preflight가 현재 세션이
 `<CLEVER_ROOT>` 기준으로 열렸는지 확인한 결과다. `pass`이면
 `<CLEVER_ROOT>/clever-agent-workspace/`와 `<CLEVER_ROOT>/projects/` 구조가 맞다.

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -148,9 +148,16 @@ CLEVER 관련 저장소는 하나의 workspace root 아래에 두는 것을 권�
   clever-agent-project/
   clever-change-control/
   clever-context-monorepo/
+  projects/
+    <project-slug>/
+      <target-repo>/
 ```
 
-generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-project`에서 시작한다. 승인 후 target GitHub repo를 생성하거나 확인한 다음, 로컬에 clone 또는 pull 하고 그 target repo 루트에서 새 세션을 시작한다.
+`<CLEVER_ROOT>`는 에이전트 제어 평면이다. 3대 레포는 항상 이 루트의 sibling으로 둔다.
+실제 제품/서비스 원격 repo는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`
+아래에 clone 또는 pull 한다. 새 target repo seed 파일은 이 target repo 루트에 주입한다.
+
+generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-project`에서 시작한다. 승인 후 target GitHub repo를 생성하거나 확인한 다음, `<CLEVER_ROOT>/projects/<project-slug>/` 아래에 로컬 clone 또는 pull 하고 그 target repo 루트에서 새 세션을 시작한다.
 
 예외는 sibling control-plane repo 자체를 직접 수정하는 경우다.
 
@@ -346,7 +353,7 @@ PR 정보를 wiki에 올리는 것이 아니다. wiki에는 필요한 서비스/
 
 ### 새 target repo 초기 seed 파일
 
-새 프로젝트 repo를 만들거나 첫 target repo를 bootstrap할 때는 프로젝트 기획 초안과 agent 실행 절차서를 분리해서 넣는다.
+새 프로젝트 repo를 만들거나 첫 target repo를 bootstrap할 때는 프로젝트 기획 초안과 agent 실행 절차서를 분리해서 넣는다. 주입 위치는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`에 clone/pull된 target repo 루트다.
 
 - [target repo AGENTS template](templates/target-repo-AGENTS.md) -> target repo `AGENTS.md`
 - [target repo project brief template](templates/target-repo-project-brief.md) -> target repo `docs/project-brief.md`

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -387,6 +387,13 @@ python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo
 이때 `recovery_actions`에 실패 check별 복구 명령이나 처리 지시가 들어간다.
 `auto_skipped_questions`는 도구가 이미 답한 질문이므로 다시 묻지 않는다.
 `next_questions`는 자동 확인 뒤에도 남아 있는 최소 사용자 질문만 담는다.
+`workspace_check.session_open_check`는 Python preflight가 현재 세션이
+`<CLEVER_ROOT>` 기준으로 열렸는지 확인한 결과다. `pass`이면
+`<CLEVER_ROOT>/clever-agent-workspace/`와 `<CLEVER_ROOT>/projects/` 구조가 맞다.
+`legacy-layout`이면 기존 direct control-plane layout에서 실행 중이라는 뜻이므로
+새 target repo는 반드시 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`에
+둔다. `fail`이면 작업 질문으로 내려가기 전에 세션 위치를 먼저 고친다.
+
 `true`이면 내부 `workspace_check.agent_action`이 아래 중 하나를 돌려준다.
 
 - `proceed-with-hard-gate`: 현재 위치에서 시작 템플릿으로 진행

--- a/docs/templates/target-repo-AGENTS.md
+++ b/docs/templates/target-repo-AGENTS.md
@@ -57,19 +57,46 @@ preflight는 최소한 `gh auth status`, gh CLI에서 확인한 GitHub login 또
 ## 작업 시작 순서
 
 새 세션 또는 새 이슈 작업을 시작하면 아래 순서로 진행한다.
+비사소한 개발 작업에서는 이슈와 GitHub Development linked branch가 준비되기
+전까지 구현, 커밋, PR 생성을 하지 않는다.
 
 1. `git status --short --branch`로 branch와 dirty 상태를 확인한다.
-2. 현재 작업이 연결된 issue를 확인한다.
-3. `project-start issue`와 `change-control issue`가 연결되어 있는지 확인한다.
-4. 현재 branch가 작업 범위와 맞는지 확인한다.
-5. `docs/project-brief.md`에서 프로젝트 목적과 제약을 확인한다.
-6. 필요한 경우 `clever-context-monorepo/docs/services/<service>/index.md`를 읽는다.
-7. 작업 전 변경 범위와 검증 방법을 짧게 정리한다.
-8. 기능 변경 또는 버그 수정은 테스트를 먼저 추가한다.
-9. 구현한다.
-10. 관련 테스트와 `git diff --check`를 실행한다.
-11. context monorepo 반영 필요 여부를 확인한다.
-12. 완료 보고에 변경 내용, 검증 결과, 남은 리스크를 남긴다.
+2. target repository에 현재 작업을 대표하는 target issue를 생성하거나 확인한다.
+3. 필요한 경우 `clever-change-control` repository에 대응 change-control issue를 생성하거나 확인한다.
+4. target issue와 change-control issue를 서로 명시적으로 링크한다.
+5. 브랜치는 반드시 target issue의 GitHub Development 기능으로 생성한다.
+6. `gh issue develop --list`로 linked branch를 확인한다.
+7. linked branch checkout 이후 `docs/project-brief.md`에서 프로젝트 목적과 제약을 확인한다.
+8. 필요한 경우 `clever-context-monorepo/docs/services/<service>/index.md`를 읽는다.
+9. 작업 전 변경 범위와 검증 방법을 짧게 정리한다.
+10. 기능 변경 또는 버그 수정은 테스트를 먼저 추가한다.
+11. 구현한다.
+12. PR 생성 전 필수 검증 명령을 실행한다.
+13. context monorepo 반영 필요 여부를 확인한다.
+14. 완료 보고에 target issue, change-control issue, linked branch, PR, merge commit, 검증 결과, 남은 후속 작업을 남긴다.
+
+### GitHub issue-linked branch 생성
+
+수동으로 `git checkout -b`를 먼저 하지 않는다. CLI를 사용할 때는 반드시 아래
+형식을 사용한다.
+
+```bash
+gh issue develop <target-issue-number> \
+  --repo <target_repo_full_name> \
+  --base dev \
+  --name cc-<change-control-issue-number>-<short-scope> \
+  --checkout
+```
+
+브랜치 생성 후 linked branch를 확인한다.
+
+```bash
+gh issue develop --list <target-issue-number> \
+  --repo <target_repo_full_name>
+```
+
+예를 들어 target repo가 `EVNSolution/thundercrew-domain`이면 `--repo
+EVNSolution/thundercrew-domain`과 `--base dev`를 사용한다.
 
 ## Branch 운영
 
@@ -164,47 +191,48 @@ scripts/apply-github-rulesets.sh <target_repo_full_name>
 실행 계정에는 target repo의 GitHub Administration write 권한이 필요하다.
 private repo로 만들어야 하는 예외가 생기면 ruleset enforce가 되지 않는 리스크를 먼저 이슈에 남긴다.
 
-## 브랜치 역할별 접두사
+## 브랜치 이름 규칙
 
-task branch는 프로젝트명이나 repo명으로 시작하지 않는다.
-`clever-` 같은 제품/조직/프로젝트 이름은 branch 역할 접두사가 아니다.
-필요하면 topic 뒤에만 넣는다.
+비사소한 개발 작업의 branch 이름은 아래 형식으로 고정한다.
 
-허용 branch:
-
-- `main`: deploy branch
-- `dev`: integration work branch
-- `feature/<issue-or-cc>-<short-topic>`: 신규 기능
-- `fix/<issue-or-cc>-<short-topic>`: 버그 수정
-- `change/<issue-or-cc>-<short-topic>`: 동작 변경
-- `refactor/<issue-or-cc>-<short-topic>`: 구조 개선
-- `docs/<issue-or-cc>-<short-topic>`: 문서 작업
-- `chore/<issue-or-cc>-<short-topic>`: 설정, 관리, 빌드 보조 작업
-- `test/<issue-or-cc>-<short-topic>`: 테스트 보강
-- `release/<env-or-version>`: 릴리스 준비
-- `hotfix/<issue-or-cc>-<short-topic>`: 긴급 수정
+```text
+cc-<change-control-issue-number>-<short-scope>
+```
 
 예:
 
-- 좋음: `feature/issue-24-login-timeout`
-- 좋음: `fix/cc-12-issue-24-login-timeout`
-- 나쁨: `clever-login-timeout`
-- 나쁨: `issue-24-login-timeout`
+```text
+cc-74-dashboard-mapstate-frontend
+```
 
-브랜치 역할 접두사를 로컬에서 강제하려면 target repo에서 아래 명령을 실행한다.
+규칙:
+
+- branch는 항상 target issue의 GitHub Development 기능으로 생성한다.
+- work branch는 항상 `dev`에서 시작한다.
+- `git checkout -b`로 임의 branch를 먼저 만들지 않는다.
+- GitHub Issue Development에 연결되지 않은 branch에서 작업하지 않는다.
+- `dev` branch에서 직접 개발하거나 직접 commit하지 않는다.
+- issue 없이 branch를 만들지 않는다.
+- branch 없이 구현하지 않는다.
+- PR 없이 `dev`에 반영하지 않는다.
+- 내부 agent/tool 이름을 public commit, PR 제목, merge commit, GitHub attribution에 불필요하게 노출하지 않는다.
+- `Co-authored-by: OmX` 같은 내부 자동화 attribution을 public dev history에 남기지 않는다.
+
+브랜치 이름과 direct push를 로컬에서 보조적으로 확인하려면 target repo에서 아래
+명령을 실행한다. 이 hook은 GitHub Development linked branch 확인을 대체하지
+않는다.
 
 ```bash
 cat > .git/hooks/pre-commit <<'EOF'
 #!/bin/sh
 branch="$(git rev-parse --abbrev-ref HEAD)"
 case "$branch" in
-  main|dev|feature/*|fix/*|change/*|refactor/*|docs/*|chore/*|test/*|release/*|hotfix/*)
+  main|dev|cc-[0-9]*-*)
     exit 0
     ;;
   *)
     echo "Invalid branch name: $branch"
-    echo "Use main, dev, or a role-prefixed task branch:"
-    echo "feature/* fix/* change/* refactor/* docs/* chore/* test/* release/* hotfix/*"
+    echo "Use main, dev, or cc-<change-control-issue-number>-<short-scope>."
     exit 1
     ;;
 esac
@@ -215,17 +243,16 @@ cat > .git/hooks/pre-push <<'EOF'
 #!/bin/sh
 branch="$(git rev-parse --abbrev-ref HEAD)"
 case "$branch" in
-  main)
-    echo "Direct pushes to main are blocked locally. Use dev or a role-prefixed task branch."
+  main|dev)
+    echo "Direct pushes to $branch are blocked locally. Use a PR."
     exit 1
     ;;
-  dev|feature/*|fix/*|change/*|refactor/*|docs/*|chore/*|test/*|release/*|hotfix/*)
+  cc-[0-9]*-*)
     exit 0
     ;;
   *)
     echo "Invalid branch name: $branch"
-    echo "Use dev or a role-prefixed task branch:"
-    echo "feature/* fix/* change/* refactor/* docs/* chore/* test/* release/* hotfix/*"
+    echo "Use cc-<change-control-issue-number>-<short-scope>."
     exit 1
     ;;
 esac
@@ -234,7 +261,7 @@ chmod +x .git/hooks/pre-push
 ```
 
 `pre-commit`은 잘못된 branch 이름에서 commit 생성을 막는다.
-`pre-push`는 `main` direct push와 잘못된 branch 이름 push를 막는다.
+`pre-push`는 `main`/`dev` direct push와 잘못된 branch 이름 push를 막는다.
 
 ## Issue 연결 규칙
 
@@ -294,6 +321,65 @@ PR을 열기 전에 현재 변경을 한 PR로 묶을지, 분리 PR로 나눌지
 
 예: OpenAPI schema 변경, Admin Web smoke 화면, Rider App smoke 화면, Spring
 service mock endpoint 구현은 보통 분리 PR로 다룬다.
+
+## PR, merge, 검증, 보고 규칙
+
+PR은 작업 branch에서 `dev`로 생성한다. PR 본문에는 target issue와
+change-control issue를 명시한다. change-control issue가 필요 없다고 판단한
+예외 작업은 그 사유를 target issue와 PR 본문에 남긴다.
+
+기본 merge 방식은 GitHub PR trace가 `dev` history에서 명확히 보이는 방식을
+우선한다. merge commit 방식을 권장한다. squash merge가 필요한 경우에도 commit
+title에는 반드시 PR 번호를 포함한다.
+
+예:
+
+```text
+Dashboard map-state frontend integration (#62)
+```
+
+금지:
+
+- PR 번호 없는 squash commit
+- `dev`에 직접 작성한 것처럼 보이는 commit title
+- 출처가 불명확한 merge commit
+- squash merge 남발
+
+PR 생성 전 최소 검증:
+
+```bash
+npm run check:workspace
+npm run lint
+npm run typecheck
+npm run build
+```
+
+프론트 테스트가 있으면 추가로 실행한다.
+
+```bash
+npm run test:service-ops
+# 관련 frontend test command
+```
+
+백엔드를 건드렸으면 추가로 실행한다.
+
+```bash
+cd development/service-ops-api && ./gradlew test
+cd development/service-ops-api && ./gradlew build
+```
+
+작업 보고는 항상 아래 기준으로 한다.
+
+1. target issue 번호
+2. change-control issue 번호
+3. linked branch 이름
+4. PR 번호
+5. merge commit
+6. 검증 명령 결과
+7. 남은 후속 작업
+
+PR merge 후 target issue와 change-control issue를 정리/close한다. merge 후 작업
+branch는 local/remote 모두 삭제한다.
 
 ## 구현 규칙
 

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -464,28 +464,68 @@ def test_target_repo_seed_templates_separate_execution_rules_from_project_brief(
     assert "agent 작업 절차" in project_brief
 
 
-def test_target_repo_agents_template_enforces_role_based_branch_prefixes():
+def test_target_repo_agents_template_enforces_github_development_branch_flow():
     agents_template = REPO_ROOT / "docs/templates/target-repo-AGENTS.md"
 
     agents = agents_template.read_text(encoding="utf-8")
 
-    assert "브랜치 역할별 접두사" in agents
-    for branch_prefix in [
-        "feature/",
-        "fix/",
-        "change/",
-        "refactor/",
-        "docs/",
-        "chore/",
-        "test/",
-        "release/",
-        "hotfix/",
-    ]:
-        assert branch_prefix in agents
+    assert "GitHub issue-linked branch 생성" in agents
+    assert "gh issue develop <target-issue-number>" in agents
+    assert "--base dev" in agents
+    assert "--name cc-<change-control-issue-number>-<short-scope>" in agents
+    assert "--checkout" in agents
+    assert "gh issue develop --list <target-issue-number>" in agents
+    assert "EVNSolution/thundercrew-domain" in agents
+    assert "git checkout -b" in agents
+    assert "## 브랜치 이름 규칙" in agents
+    assert "cc-74-dashboard-mapstate-frontend" in agents
+    assert "GitHub Issue Development에 연결되지 않은 branch" in agents
+    assert "Co-authored-by: OmX" in agents
     assert "cat > .git/hooks/pre-commit <<'EOF'" in agents
     assert "cat > .git/hooks/pre-push <<'EOF'" in agents
-    assert "main|dev|feature/*|fix/*|change/*|refactor/*|docs/*|chore/*|test/*|release/*|hotfix/*)" in agents
-    assert "clever-" in agents
+    assert "cc-[0-9]*-*" in agents
+
+
+def test_target_repo_agents_template_enforces_pr_validation_and_report_contract():
+    agents = (REPO_ROOT / "docs/templates/target-repo-AGENTS.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "PR은 작업 branch에서 `dev`로 생성한다" in agents
+    assert "PR 본문에는 target issue와" in agents
+    assert "npm run check:workspace" in agents
+    assert "npm run lint" in agents
+    assert "npm run typecheck" in agents
+    assert "npm run build" in agents
+    assert "npm run test:service-ops" in agents
+    assert "cd development/service-ops-api && ./gradlew test" in agents
+    assert "cd development/service-ops-api && ./gradlew build" in agents
+    for expected in [
+        "target issue 번호",
+        "change-control issue 번호",
+        "linked branch 이름",
+        "PR 번호",
+        "merge commit",
+        "검증 명령 결과",
+        "남은 후속 작업",
+    ]:
+        assert expected in agents
+
+
+def test_root_prompts_enforce_issue_linked_target_workflow():
+    root_agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    skill = (REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    for text in [root_agents, skill]:
+        assert "gh issue develop <target-issue-number>" in text
+        assert "--repo <target-repo-full-name>" in text
+        assert "--base dev" in text
+        assert "--name cc-<change-control-issue-number>-<short-scope>" in text
+        assert "gh issue develop --list <target-issue-number>" in text
+        assert "git checkout -b" in text
+        assert "Do not implement, commit, or open a PR" in text or "may the agent implement, commit, or open a PR" in text
 
 
 def test_target_repo_ruleset_template_applies_main_and_dev_only():

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -1438,22 +1438,22 @@ def test_readme_guides_non_expert_users_by_entry_surface():
         assert 'python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json' in prompt
 
 
-def test_readme_includes_clever_root_user_prompt_for_agent_bootstrap():
+def test_readme_includes_short_new_root_user_prompt_for_agent_bootstrap():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-    assert "### `<CLEVER_ROOT>`에서 에이전트에게 바로 붙여 넣는 프롬프트" in readme
-    root_prompt = first_text_block_after(readme, "`<CLEVER_ROOT>`에서 에이전트에게")
-    assert "지금 위치를 <CLEVER_ROOT>로 보고 CLEVER 작업을 시작해줘" in root_prompt
-    assert "바로 구현하거나 임의로 repo를 수정하지 마" in root_prompt
-    assert "<CLEVER_ROOT>/clever-agent-workspace/clever-agent-project" in root_prompt
-    assert "session_open_check" in root_prompt
-    assert "agent_response_contract" in root_prompt
+    assert "### 새 폴더에서 에이전트에게 바로 붙여 넣는 프롬프트" in readme
+    root_prompt = first_text_block_after(readme, "새 폴더에서 에이전트에게")
+    assert "새 CLEVER 작업 루트를 하나 만들고 시작해줘" in root_prompt
+    assert "<CLEVER_ROOT>/clever-agent-workspace/" in root_prompt
+    assert "https://github.com/EVNSolution/clever-agent-project.git" in root_prompt
+    assert "https://github.com/EVNSolution/clever-context-monorepo.git" in root_prompt
+    assert "https://github.com/EVNSolution/clever-change-control.git" in root_prompt
+    assert "clever-agent-project의 README와 AGENTS.md 지침" in root_prompt
+    assert "preflight와 작업 준비" in root_prompt
     assert "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>" in root_prompt
-    assert "AGENTS.md" in root_prompt
-    assert "docs/project-brief.md" in root_prompt
-    assert ".github/PULL_REQUEST_TEMPLATE.md" in root_prompt
-    assert "scripts/apply-github-rulesets.sh" in root_prompt
-    assert "초기 작업(레포 확인/생성, repo 규칙 생성 또는 확인, pull/clone, 에이전트 문서 주입)이 완료됐습니다" in root_prompt
+    assert "agent 문서를 target repo에 주입" in root_prompt
+    assert "구현, 커밋, PR 생성을 시작하지 마" in root_prompt
+    assert "초기 작업(작업 루트 생성, 3대 레포 준비, preflight, target repo 준비, 에이전트 문서 주입)이 완료됐습니다" in root_prompt
     assert "다음 작업은 주신 프롬프트대로" in root_prompt
 
 

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -256,10 +256,14 @@ def test_build_workspace_check_reports_ready_from_agent_project():
 
     assert report["control_plane_complete"] is True
     assert report["current_repo"] == "clever-agent-project"
+    assert "session_open_check" in report
     assert report["current_repo_is_start"] is True
     assert report["startup_ready"] is True
     assert report["agent_action"] == "proceed-with-hard-gate"
     assert report["missing_repositories"] == []
+    assert report["session_open_check"]["status"] in {"pass", "legacy-layout"}
+    assert "control_plane_root" in report["session_open_check"]
+    assert "projects_root" in report["session_open_check"]
 
 
 def test_build_workspace_check_requires_switch_when_started_from_change_control():
@@ -302,6 +306,47 @@ def test_build_workspace_check_reports_incomplete_workspace(tmp_path: Path):
     assert report["agent_action"] == "stop-and-fix-workspace"
     assert "clever-context-monorepo" in report["missing_repositories"]
     assert "clever-change-control" in report["missing_repositories"]
+
+
+def test_build_workspace_check_detects_clever_root_agent_workspace_layout(tmp_path: Path):
+    module = load_module()
+    clever_root = tmp_path / "CLEVER_ROOT"
+    agent_workspace = clever_root / "clever-agent-workspace"
+    projects_root = clever_root / "projects"
+    for repo_name in [
+        "clever-agent-project",
+        "clever-context-monorepo",
+        "clever-change-control",
+    ]:
+        (agent_workspace / repo_name).mkdir(parents=True)
+    projects_root.mkdir()
+
+    monkeypatch_values = {
+        agent_workspace / "clever-agent-project": "clever-agent-project",
+        agent_workspace / "clever-context-monorepo": "clever-context-monorepo",
+        agent_workspace / "clever-change-control": "clever-change-control",
+    }
+
+    def fake_git_root(path: Path):
+        path = path.resolve()
+        for candidate in monkeypatch_values:
+            if path == candidate or candidate in path.parents:
+                return candidate
+        return None
+
+    module.try_find_git_root = fake_git_root
+    module.try_repo_name = lambda path: monkeypatch_values.get(path) if path else None
+    module.current_branch = lambda _path: "main"
+    module.is_checkout_root = lambda path: path in monkeypatch_values
+
+    report = module.build_workspace_check(agent_workspace / "clever-agent-project")
+
+    assert report["clever_work_root"] == str(clever_root)
+    assert report["control_plane_root"] == str(agent_workspace)
+    assert report["projects_root"] == str(projects_root)
+    assert report["session_open_check"]["status"] == "pass"
+    assert report["session_open_check"]["layout_mode"] == "clever-root-with-agent-workspace"
+    assert report["recommended_start_repo"] == str(agent_workspace / "clever-agent-project")
 
 
 @pytest.mark.skipif(
@@ -501,6 +546,8 @@ def test_control_plane_docs_define_projects_folder_layout():
     setting = (REPO_ROOT / "docs/setting.md").read_text(encoding="utf-8")
     assert "3대 레포는 항상 그 안의 sibling" in setting
     assert "target repo 루트에 주입" in setting
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "session_open_check" in agents
 
 
 def test_target_repo_agents_template_enforces_github_development_branch_flow():

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -548,6 +548,15 @@ def test_control_plane_docs_define_projects_folder_layout():
     assert "target repo 루트에 주입" in setting
     agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
     assert "session_open_check" in agents
+    assert "agent_response_contract" in agents
+    assert "초기 작업" in agents
+    assert "주신 프롬프트대로" in agents
+
+    setting = (REPO_ROOT / "docs/setting.md").read_text(encoding="utf-8")
+    skill = (REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md").read_text(encoding="utf-8")
+    for text in [setting, skill]:
+        assert "agent_response_contract" in text
+        assert "바로 구현하지" in text or "do not start CLEVER work from a freeform prompt" in text
 
 
 def test_target_repo_agents_template_enforces_github_development_branch_flow():
@@ -1110,6 +1119,11 @@ def test_preflight_check_reports_auto_skips_and_next_startup_question(monkeypatc
             "reason": "preflight passed and the workspace is ready for the startup template.",
         }
     ]
+    contract = report["agent_response_contract"]
+    assert contract["do_not_start_freeform_work"] is True
+    assert "에이전트 기반 preflight" in contract["immediate_reply_style"]
+    assert "초기 작업" in contract["after_initial_setup_success_reply_style"]
+    assert "주신 프롬프트대로" in contract["after_initial_setup_success_reply_style"]
 
 
 def test_preflight_check_infers_github_login_from_gh_cli_when_expected_missing(monkeypatch):

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -1438,6 +1438,25 @@ def test_readme_guides_non_expert_users_by_entry_surface():
         assert 'python3 scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json' in prompt
 
 
+def test_readme_includes_clever_root_user_prompt_for_agent_bootstrap():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "### `<CLEVER_ROOT>`에서 에이전트에게 바로 붙여 넣는 프롬프트" in readme
+    root_prompt = first_text_block_after(readme, "`<CLEVER_ROOT>`에서 에이전트에게")
+    assert "지금 위치를 <CLEVER_ROOT>로 보고 CLEVER 작업을 시작해줘" in root_prompt
+    assert "바로 구현하거나 임의로 repo를 수정하지 마" in root_prompt
+    assert "<CLEVER_ROOT>/clever-agent-workspace/clever-agent-project" in root_prompt
+    assert "session_open_check" in root_prompt
+    assert "agent_response_contract" in root_prompt
+    assert "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>" in root_prompt
+    assert "AGENTS.md" in root_prompt
+    assert "docs/project-brief.md" in root_prompt
+    assert ".github/PULL_REQUEST_TEMPLATE.md" in root_prompt
+    assert "scripts/apply-github-rulesets.sh" in root_prompt
+    assert "초기 작업(레포 확인/생성, repo 규칙 생성 또는 확인, pull/clone, 에이전트 문서 주입)이 완료됐습니다" in root_prompt
+    assert "다음 작업은 주신 프롬프트대로" in root_prompt
+
+
 def test_startup_first_questions_prioritize_project_and_service_scope():
     docs = [
         REPO_ROOT / "README.md",

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -435,7 +435,7 @@ def test_build_packet_includes_target_repo_seed_files():
         },
     ]
     assert packet["repo_bootstrap"]["local_folder_layout"] == {
-        "control_plane_root": "<CLEVER_ROOT>",
+        "control_plane_root": "<CLEVER_ROOT>/clever-agent-workspace",
         "control_plane_repositories": [
             "clever-agent-project",
             "clever-context-monorepo",
@@ -490,6 +490,7 @@ def test_control_plane_docs_define_projects_folder_layout():
     for doc_path in docs:
         text = doc_path.read_text(encoding="utf-8")
         assert "<CLEVER_ROOT>/" in text
+        assert "clever-agent-workspace/" in text
         assert "clever-agent-project/" in text
         assert "clever-context-monorepo/" in text
         assert "clever-change-control/" in text
@@ -498,7 +499,7 @@ def test_control_plane_docs_define_projects_folder_layout():
         assert "<target-repo>/" in text
 
     setting = (REPO_ROOT / "docs/setting.md").read_text(encoding="utf-8")
-    assert "3대 레포는 항상 이 루트의 sibling" in setting
+    assert "3대 레포는 항상 그 안의 sibling" in setting
     assert "target repo 루트에 주입" in setting
 
 

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -434,9 +434,24 @@ def test_build_packet_includes_target_repo_seed_files():
             ],
         },
     ]
+    assert packet["repo_bootstrap"]["local_folder_layout"] == {
+        "control_plane_root": "<CLEVER_ROOT>",
+        "control_plane_repositories": [
+            "clever-agent-project",
+            "clever-context-monorepo",
+            "clever-change-control",
+        ],
+        "project_repositories_root": "<CLEVER_ROOT>/projects/<project-slug>",
+        "target_repo_checkout": "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+        "seed_injection_root": "target repo root",
+    }
     assert (
-        "copy target repo seed files before handoff"
+        "copy target repo seed files into the target repo root before handoff"
         in packet["repo_bootstrap"]["post_create_clone"]
+    )
+    assert any(
+        "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>" in step
+        for step in packet["repo_bootstrap"]["post_create_clone"]
     )
     assert (
         "apply GitHub rulesets after dev exists"
@@ -462,6 +477,29 @@ def test_target_repo_seed_templates_separate_execution_rules_from_project_brief(
     assert "초기 범위" in project_brief
     assert "다음 작업 목록" in project_brief
     assert "agent 작업 절차" in project_brief
+
+
+def test_control_plane_docs_define_projects_folder_layout():
+    docs = [
+        REPO_ROOT / "AGENTS.md",
+        REPO_ROOT / "README.md",
+        REPO_ROOT / "docs/setting.md",
+        REPO_ROOT / ".agent/skills/bootstrap-clever-work/SKILL.md",
+    ]
+
+    for doc_path in docs:
+        text = doc_path.read_text(encoding="utf-8")
+        assert "<CLEVER_ROOT>/" in text
+        assert "clever-agent-project/" in text
+        assert "clever-context-monorepo/" in text
+        assert "clever-change-control/" in text
+        assert "projects/" in text
+        assert "<project-slug>/" in text
+        assert "<target-repo>/" in text
+
+    setting = (REPO_ROOT / "docs/setting.md").read_text(encoding="utf-8")
+    assert "3대 레포는 항상 이 루트의 sibling" in setting
+    assert "target repo 루트에 주입" in setting
 
 
 def test_target_repo_agents_template_enforces_github_development_branch_flow():
@@ -722,15 +760,19 @@ def test_build_packet_includes_post_create_clone_and_handoff_plan():
 
     assert repo_bootstrap["post_create_clone"] == [
         "create-or-confirm public target repo after project-start approval",
-        "clone-or-pull the target repo locally",
-        "copy target repo seed files before handoff",
+        "clone-or-pull the target repo under <CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+        "copy target repo seed files into the target repo root before handoff",
         "apply GitHub rulesets after dev exists",
         "verify local checkout is ready for follow-on work",
     ]
+    assert repo_bootstrap["local_folder_layout"]["target_repo_checkout"] == (
+        "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>"
+    )
     assert handoff["recommended_session"] == "new-target-repo-session"
     assert handoff["status"] == "recommended-after-clone"
     assert "Switch to the cloned target repo" in handoff["summary"]
     assert "seed AGENTS.md and docs/project-brief.md" in handoff["summary"]
+    assert "projects folder" in packet["next_step"]
     assert "seed the target repo" in packet["next_step"]
 
 


### PR DESCRIPTION
## Summary
- Enforce target-repository work as a GitHub issue-linked workflow in the root agent contract.
- Add scoped target-work guidance to the bootstrap skill after target repo creation.
- Update the target repo AGENTS template to require target issue, optional change-control issue, GitHub Development branch creation, linked branch verification, PR-to-dev, validation, merge, cleanup, and reporting rules.
- Define the local folder structure: the three control-plane repos live under `<CLEVER_ROOT>/clever-agent-workspace/`, and product/service target repos live under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/` where agent seed documents are injected.
- Add Python preflight `workspace_check.session_open_check` so bootstrap validation confirms the CLEVER_ROOT-based session layout before startup questions.
- Add `preflight_check.agent_response_contract` so prompts received at `<CLEVER_ROOT>` do not trigger ad-hoc work; the agent first inherits the CLEVER workflow, completes initial setup, then continues with the user's prompt.
- Add a concise GitHub README copy-paste prompt: create a CLEVER root folder, fetch the three control-plane repos, then follow `clever-agent-project` to prepare the work.
- Update regression tests for the branch/PR workflow, project checkout layout, session-root validation, root-prompt response style, and README prompt.

## Intended folder layout
```text
<CLEVER_ROOT>/
  clever-agent-workspace/
    clever-agent-project/
    clever-context-monorepo/
    clever-change-control/
  projects/
    <project-slug>/
      <target-repo>/
        AGENTS.md
        docs/project-brief.md
        .github/PULL_REQUEST_TEMPLATE.md
        scripts/apply-github-rulesets.sh
```

## README root prompt shape
The README now provides a short user-facing prompt that says, in effect:

> 새 CLEVER 작업 루트를 하나 만들고, `clever-agent-workspace` 아래에 3대 레포를 받은 뒤, `clever-agent-project`의 README/AGENTS 지침에 따라 preflight와 작업 준비를 진행해줘. 초기 준비 전에는 구현/커밋/PR을 시작하지 말고, 준비가 끝나면 다음 작업은 주신 프롬프트대로 진행하겠다고 답해줘.

## Linked issues
- target issue: EVNSolution/clever-agent-project#34
- clever-change-control issue: EVNSolution/clever-change-control#75

## Concurrent Work Gate
- parallel work decision: allowed-with-non-overlap
- target repo issue: EVNSolution/clever-agent-project#34
- clever-change-control issue: EVNSolution/clever-change-control#75
- open PR checked: no overlapping open PR found during this branch work
- conflict candidates: none identified

## Validation
- `python3 -m pytest -q` — 84 passed, 2 skipped
- `python3 .agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json` — emitted `workspace_check.session_open_check` (`legacy-layout` in this current checkout, with expected nested path reported)
- `python3 -m py_compile .agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py` — passed
- `git diff --check` — passed
- npm/Gradle target app commands — not applicable; this control-plane repo has no package or service backend manifest

## Notes
- This control-plane repository uses `main` as the protected PR base; the prompt changes themselves instruct target repositories to use work branches from `dev` and PRs into `dev`.
