### PR TITLE
Simplify CLEVER target repo path

### DIFF
--- a/.agent/skills/bootstrap-clever-work/SKILL.md
+++ b/.agent/skills/bootstrap-clever-work/SKILL.md
@@ -35,13 +35,12 @@ Use this local folder layout unless the user has explicitly provided another pat
     clever-context-monorepo/
     clever-change-control/
   projects/
-    <project-slug>/
-      <target-repo>/
+    <target-repo>/
 ```
 
 The three agent/control-plane repositories stay under `<CLEVER_ROOT>/clever-agent-workspace/`.
 Remote product/service repositories are cloned or pulled under
-`<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`. Seed files are copied
+`<CLEVER_ROOT>/projects/<target-repo>/`. Seed files are copied
 into that target repo root.
 
 - `AGENTS.md`: agent execution procedure, working order, issue/branch rules, verification, context update checks, and completion conditions
@@ -72,7 +71,7 @@ Interpret the result like this:
 - Always read `workspace_check.session_open_check` before startup questions. The
   Python preflight must confirm the CLEVER_ROOT-based session layout first:
   three control-plane repos under `<CLEVER_ROOT>/clever-agent-workspace/`, target
-  repos under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`.
+  repos under `<CLEVER_ROOT>/projects/<target-repo>/`.
 - Always read `preflight_check.agent_response_contract` before replying to a
   CLEVER_ROOT-level prompt. It defines the response style: inherit the CLEVER
   agent workflow, complete initial setup, then continue with the provided prompt.
@@ -390,7 +389,7 @@ Once the user approves:
    - 새 target repo는 public으로 생성한다.
    - Use `gh repo create <owner>/<repo> --public` for a newly created target repo.
    - GitHub Free organization rulesets are enforced on public repositories; private repository enforcement requires GitHub Team, GitHub Pro, or GitHub Enterprise Cloud.
-5. Clone or pull the target repo under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`.
+5. Clone or pull the target repo under `<CLEVER_ROOT>/projects/<target-repo>/`.
 6. Copy the target repo seed files before handoff:
    - `docs/templates/target-repo-AGENTS.md` -> target repo `AGENTS.md`
    - `docs/templates/target-repo-project-brief.md` -> target repo `docs/project-brief.md`

--- a/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
+++ b/.agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py
@@ -252,7 +252,7 @@ def infer_workspace_root(start: Path, git_root: Path | None = None) -> Path:
     Preferred layout:
 
         <CLEVER_ROOT>/clever-agent-workspace/{three control-plane repos}
-        <CLEVER_ROOT>/projects/<project-slug>/<target-repo>
+        <CLEVER_ROOT>/projects/<target-repo>
 
     Legacy direct layout is still recognized so existing local checkouts can report
     a useful migration-oriented preflight instead of failing path discovery.
@@ -747,7 +747,7 @@ def build_agent_response_contract(workspace_check: dict[str, Any]) -> dict[str, 
         "confirm the CLEVER_ROOT session layout with workspace_check.session_open_check",
         "create or confirm the target repository only after the project-start gate",
         "apply or confirm repository rules before normal development",
-        "clone or pull the target repo under <CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+        "clone or pull the target repo under <CLEVER_ROOT>/projects/<target-repo>",
         "inject AGENTS.md, docs/project-brief.md, PR template, and ruleset script into the target repo root",
         "after initial setup succeeds, continue according to the user's provided prompt",
     ]
@@ -1483,13 +1483,13 @@ def build_packet(
                     "clever-context-monorepo",
                     "clever-change-control",
                 ],
-                "project_repositories_root": "<CLEVER_ROOT>/projects/<project-slug>",
-                "target_repo_checkout": "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+                "project_repositories_root": "<CLEVER_ROOT>/projects",
+                "target_repo_checkout": "<CLEVER_ROOT>/projects/<target-repo>",
                 "seed_injection_root": "target repo root",
             },
             "post_create_clone": [
                 "create-or-confirm public target repo after project-start approval",
-                "clone-or-pull the target repo under <CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+                "clone-or-pull the target repo under <CLEVER_ROOT>/projects/<target-repo>",
                 "copy target repo seed files into the target repo root before handoff",
                 "apply GitHub rulesets after dev exists",
                 "verify local checkout is ready for follow-on work",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,12 @@ Recommended local layout:
     clever-context-monorepo/
     clever-change-control/
   projects/
-    <project-slug>/
-      <target-repo>/
+    <target-repo>/
 ```
 
 `<CLEVER_ROOT>` is the top-level CLEVER work root. Keep the three agent/control
 repositories inside `<CLEVER_ROOT>/clever-agent-workspace/`. Put real product/service target
-repositories under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`. When
+repositories under `<CLEVER_ROOT>/projects/<target-repo>/`. When
 bootstrapping a target repo, clone or pull the remote repo into that project
 folder, then inject the agent documents into the target repo root.
 
@@ -86,7 +85,7 @@ Read these preflight output fields before asking anything:
 - `workspace_check.session_open_check`: the Python preflight's CLEVER_ROOT-based
   session-open validation. It must confirm the expected structure
   `<CLEVER_ROOT>/clever-agent-workspace/{three control-plane repos}` and
-  `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>` before startup work
+  `<CLEVER_ROOT>/projects/<target-repo>` before startup work
   proceeds. If it reports `legacy-layout`, treat it as a migration warning and
   keep the target project checkout under `<CLEVER_ROOT>/projects/`. If it
   reports `fail`, stop and fix the session location first.
@@ -778,7 +777,7 @@ The expected operating flow is:
 5. Anchor the root line in `clever-change-control`
 6. Fix scoped execution
 7. Apply or confirm the repo branch operating contract
-8. Handoff to the target repository under `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`
+8. Handoff to the target repository under `<CLEVER_ROOT>/projects/<target-repo>/`
 9. Feed rollout / rollback / release evidence back into `clever-change-control`
 
 ## If The Workspace Is Incomplete

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ CLEVER는 한 가지 앱 전용 흐름이 아니다. 사용자가 익숙한 도�
 첫 화면에서는 직접 shell 명령보다 **어떤 환경에서 시작하는지**를 먼저 고른다.
 공통 원칙은 **3개 레포를 같은 로컬 workspace에 두고, 일반 시작은 `clever-agent-project`에서 진행한다**는 점이다.
 
-권장 폴더 구조는 아래처럼 나눈다. `<CLEVER_ROOT>`는 전체 CLEVER 작업 루트이고, 에이전트 제어 평면은 `<CLEVER_ROOT>/clever-agent-workspace/`이며, 실제 제품/서비스 코드는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/` 아래에 둔다. target repo를 만들거나 확인한 뒤에는 이 프로젝트 폴더에 원격 repo를 clone/pull 하고, 그 repo 루트에 `AGENTS.md`, `docs/project-brief.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `scripts/apply-github-rulesets.sh`를 주입한다.
+권장 폴더 구조는 아래처럼 나눈다. `<CLEVER_ROOT>`는 전체 CLEVER 작업 루트이고, 에이전트 제어 평면은 `<CLEVER_ROOT>/clever-agent-workspace/`이며, 실제 제품/서비스 코드는 `<CLEVER_ROOT>/projects/<target-repo>/` 아래에 둔다. target repo를 만들거나 확인한 뒤에는 이 target repo 폴더에 원격 repo를 clone/pull 하고, 그 repo 루트에 `AGENTS.md`, `docs/project-brief.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `scripts/apply-github-rulesets.sh`를 주입한다.
 
 ```text
 <CLEVER_ROOT>/
@@ -28,12 +28,11 @@ CLEVER는 한 가지 앱 전용 흐름이 아니다. 사용자가 익숙한 도�
     clever-context-monorepo/
     clever-change-control/
   projects/
-    <project-slug>/
-      <target-repo>/
-        AGENTS.md
-        docs/project-brief.md
-        .github/PULL_REQUEST_TEMPLATE.md
-        scripts/apply-github-rulesets.sh
+    <target-repo>/
+      AGENTS.md
+      docs/project-brief.md
+      .github/PULL_REQUEST_TEMPLATE.md
+      scripts/apply-github-rulesets.sh
 ```
 
 브라우저에서 버튼과 텍스트 입력으로 한 번에 정리하려면 [GitHub Pages 시작 도우미](https://evnsolution.github.io/clever-agent-project/start/)를 사용한다. 버튼과 텍스트 입력으로 답한 뒤 최종 copy text를 만들고, 에이전트에 붙여 넣을 위치까지 안내한다.
@@ -52,7 +51,7 @@ CLEVER는 한 가지 앱 전용 흐름이 아니다. 사용자가 익숙한 도�
    - https://github.com/EVNSolution/clever-change-control.git
 3. 이후 작업 기준은 <CLEVER_ROOT>/clever-agent-workspace/clever-agent-project 로 잡아줘.
 4. clever-agent-project의 README와 AGENTS.md 지침을 읽고, 그 지침에 따라 preflight와 작업 준비를 진행해줘.
-5. 실제 제품/서비스 target repo는 <CLEVER_ROOT>/projects/<project-slug>/<target-repo>/ 아래에 준비해줘.
+5. 실제 제품/서비스 target repo는 <CLEVER_ROOT>/projects/<target-repo>/ 아래에 준비해줘.
 6. target repo를 만들거나 확인한 뒤에는 clever-agent-project 지침에 따라 agent 문서를 target repo에 주입해줘.
 7. 초기 준비가 끝나기 전에는 구현, 커밋, PR 생성을 시작하지 마.
 8. 초기 준비가 성공하면 아래 형식으로 답해줘.

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -150,15 +150,14 @@ CLEVER 관련 저장소는 하나의 workspace root 아래에 두는 것을 권�
     clever-change-control/
     clever-context-monorepo/
   projects/
-    <project-slug>/
-      <target-repo>/
+    <target-repo>/
 ```
 
 `<CLEVER_ROOT>`는 전체 CLEVER 작업 루트다. 에이전트 제어 평면은 `<CLEVER_ROOT>/clever-agent-workspace/`이고, 3대 레포는 항상 그 안의 sibling으로 둔다.
-실제 제품/서비스 원격 repo는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`
+실제 제품/서비스 원격 repo는 `<CLEVER_ROOT>/projects/<target-repo>/`
 아래에 clone 또는 pull 한다. 새 target repo seed 파일은 이 target repo 루트에 주입한다.
 
-generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-workspace/clever-agent-project`에서 시작한다. 승인 후 target GitHub repo를 생성하거나 확인한 다음, `<CLEVER_ROOT>/projects/<project-slug>/` 아래에 로컬 clone 또는 pull 하고 그 target repo 루트에서 새 세션을 시작한다.
+generic CLEVER startup 세션은 `<CLEVER_ROOT>/clever-agent-workspace/clever-agent-project`에서 시작한다. 승인 후 target GitHub repo를 생성하거나 확인한 다음, `<CLEVER_ROOT>/projects/` 아래에 로컬 clone 또는 pull 하고 그 target repo 루트에서 새 세션을 시작한다.
 
 예외는 sibling control-plane repo 자체를 직접 수정하는 경우다.
 
@@ -354,7 +353,7 @@ PR 정보를 wiki에 올리는 것이 아니다. wiki에는 필요한 서비스/
 
 ### 새 target repo 초기 seed 파일
 
-새 프로젝트 repo를 만들거나 첫 target repo를 bootstrap할 때는 프로젝트 기획 초안과 agent 실행 절차서를 분리해서 넣는다. 주입 위치는 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`에 clone/pull된 target repo 루트다.
+새 target repo를 만들거나 첫 target repo를 bootstrap할 때는 프로젝트 기획 초안과 agent 실행 절차서를 분리해서 넣는다. 주입 위치는 `<CLEVER_ROOT>/projects/<target-repo>/`에 clone/pull된 target repo 루트다.
 
 - [target repo AGENTS template](templates/target-repo-AGENTS.md) -> target repo `AGENTS.md`
 - [target repo project brief template](templates/target-repo-project-brief.md) -> target repo `docs/project-brief.md`
@@ -397,7 +396,7 @@ pull/clone, target repo agent 문서 주입을 먼저 끝낸 뒤 "초기 작업�
 `<CLEVER_ROOT>` 기준으로 열렸는지 확인한 결과다. `pass`이면
 `<CLEVER_ROOT>/clever-agent-workspace/`와 `<CLEVER_ROOT>/projects/` 구조가 맞다.
 `legacy-layout`이면 기존 direct control-plane layout에서 실행 중이라는 뜻이므로
-새 target repo는 반드시 `<CLEVER_ROOT>/projects/<project-slug>/<target-repo>/`에
+새 target repo는 반드시 `<CLEVER_ROOT>/projects/<target-repo>/`에
 둔다. `fail`이면 작업 질문으로 내려가기 전에 세션 위치를 먼저 고친다.
 
 `true`이면 내부 `workspace_check.agent_action`이 아래 중 하나를 돌려준다.

--- a/tests/test_bootstrap_clever_work.py
+++ b/tests/test_bootstrap_clever_work.py
@@ -486,8 +486,8 @@ def test_build_packet_includes_target_repo_seed_files():
             "clever-context-monorepo",
             "clever-change-control",
         ],
-        "project_repositories_root": "<CLEVER_ROOT>/projects/<project-slug>",
-        "target_repo_checkout": "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+        "project_repositories_root": "<CLEVER_ROOT>/projects",
+        "target_repo_checkout": "<CLEVER_ROOT>/projects/<target-repo>",
         "seed_injection_root": "target repo root",
     }
     assert (
@@ -495,7 +495,7 @@ def test_build_packet_includes_target_repo_seed_files():
         in packet["repo_bootstrap"]["post_create_clone"]
     )
     assert any(
-        "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>" in step
+        "<CLEVER_ROOT>/projects/<target-repo>" in step
         for step in packet["repo_bootstrap"]["post_create_clone"]
     )
     assert (
@@ -540,7 +540,8 @@ def test_control_plane_docs_define_projects_folder_layout():
         assert "clever-context-monorepo/" in text
         assert "clever-change-control/" in text
         assert "projects/" in text
-        assert "<project-slug>/" in text
+        assert "<project-slug>" not in text
+        assert "projects/<target-repo>" in text
         assert "<target-repo>/" in text
 
     setting = (REPO_ROOT / "docs/setting.md").read_text(encoding="utf-8")
@@ -817,13 +818,13 @@ def test_build_packet_includes_post_create_clone_and_handoff_plan():
 
     assert repo_bootstrap["post_create_clone"] == [
         "create-or-confirm public target repo after project-start approval",
-        "clone-or-pull the target repo under <CLEVER_ROOT>/projects/<project-slug>/<target-repo>",
+        "clone-or-pull the target repo under <CLEVER_ROOT>/projects/<target-repo>",
         "copy target repo seed files into the target repo root before handoff",
         "apply GitHub rulesets after dev exists",
         "verify local checkout is ready for follow-on work",
     ]
     assert repo_bootstrap["local_folder_layout"]["target_repo_checkout"] == (
-        "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>"
+        "<CLEVER_ROOT>/projects/<target-repo>"
     )
     assert handoff["recommended_session"] == "new-target-repo-session"
     assert handoff["status"] == "recommended-after-clone"
@@ -1450,7 +1451,7 @@ def test_readme_includes_short_new_root_user_prompt_for_agent_bootstrap():
     assert "https://github.com/EVNSolution/clever-change-control.git" in root_prompt
     assert "clever-agent-project의 README와 AGENTS.md 지침" in root_prompt
     assert "preflight와 작업 준비" in root_prompt
-    assert "<CLEVER_ROOT>/projects/<project-slug>/<target-repo>" in root_prompt
+    assert "<CLEVER_ROOT>/projects/<target-repo>" in root_prompt
     assert "agent 문서를 target repo에 주입" in root_prompt
     assert "구현, 커밋, PR 생성을 시작하지 마" in root_prompt
     assert "초기 작업(작업 루트 생성, 3대 레포 준비, preflight, target repo 준비, 에이전트 문서 주입)이 완료됐습니다" in root_prompt


### PR DESCRIPTION
## Summary
- Remove the unused `<project-slug>` directory layer from CLEVER target repo checkout guidance.
- Align README, AGENTS.md, settings docs, bootstrap skill, generated bootstrap packet strings, and regression tests around `<CLEVER_ROOT>/projects/<target-repo>/`.
- Add docs regression coverage that rejects reintroducing `<project-slug>` in control-plane layout docs.

## Issues
- Target issue: Fixes EVNSolution/clever-agent-project#36
- Change-control issue: EVNSolution/clever-change-control#77

## Validation
- `python3 -m pytest -q` → 84 passed, 2 skipped
- `python3 -m py_compile .agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py` → exit 0
- `git diff --check` → exit 0
- `rg -n "project-slug|projects/<project-slug>" README.md AGENTS.md docs .agent/skills/bootstrap-clever-work/SKILL.md .agent/skills/bootstrap-clever-work/scripts/bootstrap_clever_work.py` → no matches

## Notes
- Live fresh-root bootstrap clone into `projects/<target-repo>` was not run.
